### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,23 +48,23 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.11.3</version>
+            <version>1.14.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
+            <version>31.0.1-jre</version>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/mineskin/MineskinClient.java
+++ b/src/main/java/org/mineskin/MineskinClient.java
@@ -11,7 +11,6 @@ import org.mineskin.data.Skin;
 import org.mineskin.data.SkinCallback;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
 import java.awt.image.RenderedImage;
 import java.io.*;
 import java.util.UUID;
@@ -36,7 +35,6 @@ public class MineskinClient {
     private final String userAgent;
     private final String apiKey;
 
-    private final JsonParser jsonParser = new JsonParser();
     private final Gson gson = new Gson();
 
     private long nextRequest = 0;
@@ -471,7 +469,7 @@ public class MineskinClient {
     @Deprecated
     void handleResponse(String body, SkinCallback callback) {
         try {
-            JsonObject jsonObject = jsonParser.parse(body).getAsJsonObject();
+            JsonObject jsonObject = JsonParser.parseString(body).getAsJsonObject();
             if (jsonObject.has("error")) {
                 callback.error(jsonObject.get("error").getAsString());
                 return;


### PR DESCRIPTION
`gson` is out of date and the way it is implemented overlaps with the project and other dependency in the project that MineskinClient was implemented in as a dependency.
I am not familiar with maven to use that but AFAIK, in gradle it would be useful to use `implementation` instead of `api` to add a library, maybe similar it's with maven?
I upgraded `gson` instead to fix the issue for now :P