### PR TITLE
Fix generateUser method to use "uuid" instead of "user"

### DIFF
--- a/src/main/java/org/mineskin/MineskinClient.java
+++ b/src/main/java/org/mineskin/MineskinClient.java
@@ -237,7 +237,7 @@ public class MineskinClient {
                 }
 
                 JsonObject body = options.toJson();
-                body.addProperty("user", uuid.toString());
+                body.addProperty("uuid", uuid.toString());
                 Connection connection = generateRequest("/user")
                         .header("Content-Type", "application/json")
                         .requestBody(body.toString());


### PR DESCRIPTION
As stated in the REST api docs, we are supposed to use "uuid": "xxx" rather than "user": "xxx".
This commit just updates this in the code since the code on the master branch at the time of writing fails to execute.