### PR TITLE
Change JUnit dependency scope to test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
JUnit is used only for tests. There is no need to include JUnit in the compiled .jar file, as it is only increases file weight.