### PR TITLE
3.2.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,24 +81,24 @@ public class Example {
     <dependency>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client</artifactId>
-        <version>3.0.7-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-jsoup</artifactId>
-        <version>3.0.7-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <!-- alternatively use apache httpcommons -->
     <!--    <dependency>-->
     <!--        <groupId>org.mineskin</groupId>-->
     <!--        <artifactId>java-client-apache</artifactId>-->
-    <!--        <version>3.0.7-SNAPSHOT</version>-->
+    <!--        <version>3.1.0-SNAPSHOT</version>-->
     <!--    </dependency>-->
     <!-- ... or java 11 HttpRequest -->
     <!--    <dependency>-->
     <!--        <groupId>org.mineskin</groupId>-->
     <!--        <artifactId>java-client-java11</artifactId>-->
-    <!--        <version>3.0.7-SNAPSHOT</version>-->
+    <!--        <version>3.1.0-SNAPSHOT</version>-->
     <!--    </dependency>-->
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -81,24 +81,24 @@ public class Example {
     <dependency>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7-SNAPSHOT</version>
     </dependency>
     <dependency>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-jsoup</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7-SNAPSHOT</version>
     </dependency>
     <!-- alternatively use apache httpcommons -->
     <!--    <dependency>-->
     <!--        <groupId>org.mineskin</groupId>-->
     <!--        <artifactId>java-client-apache</artifactId>-->
-    <!--        <version>3.0.6-SNAPSHOT</version>-->
+    <!--        <version>3.0.7-SNAPSHOT</version>-->
     <!--    </dependency>-->
     <!-- ... or java 11 HttpRequest -->
     <!--    <dependency>-->
     <!--        <groupId>org.mineskin</groupId>-->
     <!--        <artifactId>java-client-java11</artifactId>-->
-    <!--        <version>3.0.6-SNAPSHOT</version>-->
+    <!--        <version>3.0.7-SNAPSHOT</version>-->
     <!--    </dependency>-->
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ public class Example {
             .apiKey("your-api-key") // TODO: update this with your own API key (https://account.mineskin.org/keys)
             /*
              Uncomment this if you're on a paid plan with higher concurrency limits
-            .generateQueueOptions(new QueueOptions(Executors.newSingleThreadScheduledExecutor(), 200, 5concurrency))
+            .generateQueueOptions(new QueueOptions(Executors.newSingleThreadScheduledExecutor(), 200, 5))
              */
             .build();
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ public class Example {
             .requestHandler(JsoupRequestHandler::new)
             .userAgent("MyMineSkinApp/v1.0") // TODO: update this with your own user agent
             .apiKey("your-api-key") // TODO: update this with your own API key (https://account.mineskin.org/keys)
+            /*
+             Uncomment this if you're on a paid plan with higher concurrency limits
+            .generateQueueOptions(new QueueOptions(Executors.newSingleThreadScheduledExecutor(), 200, 5concurrency))
+             */
             .build();
 
     public static void main(String[] args) {

--- a/README.md
+++ b/README.md
@@ -81,24 +81,24 @@ public class Example {
     <dependency>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-jsoup</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </dependency>
     <!-- alternatively use apache httpcommons -->
     <!--    <dependency>-->
     <!--        <groupId>org.mineskin</groupId>-->
     <!--        <artifactId>java-client-apache</artifactId>-->
-    <!--        <version>3.1.0-SNAPSHOT</version>-->
+    <!--        <version>3.2.0-SNAPSHOT</version>-->
     <!--    </dependency>-->
     <!-- ... or java 11 HttpRequest -->
     <!--    <dependency>-->
     <!--        <groupId>org.mineskin</groupId>-->
     <!--        <artifactId>java-client-java11</artifactId>-->
-    <!--        <version>3.1.0-SNAPSHOT</version>-->
+    <!--        <version>3.2.0-SNAPSHOT</version>-->
     <!--    </dependency>-->
 </dependencies>
 ```

--- a/apache/pom.xml
+++ b/apache/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-apache</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.0.7-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>22</maven.compiler.source>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/apache/pom.xml
+++ b/apache/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-apache</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>22</maven.compiler.source>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.2.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/apache/pom.xml
+++ b/apache/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.7-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-apache</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>22</maven.compiler.source>
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.7-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.7-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.0.7-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/core/src/main/java/org/mineskin/ClientBuilder.java
+++ b/core/src/main/java/org/mineskin/ClientBuilder.java
@@ -1,6 +1,7 @@
 package org.mineskin;
 
 import com.google.gson.Gson;
+import org.mineskin.options.AutoGenerateQueueOptions;
 import org.mineskin.options.IJobCheckOptions;
 import org.mineskin.options.IQueueOptions;
 import org.mineskin.request.RequestHandler;
@@ -115,6 +116,7 @@ public class ClientBuilder {
     /**
      * Set the options for submitting queue jobs<br/>
      * defaults to 200ms interval and 1 concurrent request
+     *
      * @see QueueOptions
      */
     public ClientBuilder generateQueueOptions(IQueueOptions queueOptions) {
@@ -136,6 +138,7 @@ public class ClientBuilder {
     /**
      * Set the options for get requests, e.g. getting skins<br/>
      * defaults to 100ms interval and 5 concurrent requests
+     *
      * @see QueueOptions
      */
     public ClientBuilder getQueueOptions(IQueueOptions queueOptions) {
@@ -150,13 +153,14 @@ public class ClientBuilder {
      */
     @Deprecated
     public ClientBuilder jobCheckScheduler(ScheduledExecutorService scheduledExecutor) {
-        this.jobCheckOptions = new JobCheckOptions(scheduledExecutor, DEFAULT_JOB_CHECK_INTERVAL, DEFAULT_JOB_CHECK_INITIAL_DELAY, DEFAULT_JOB_CHECK_MAX_ATTEMPTS);
+        this.jobCheckOptions = new JobCheckOptions(scheduledExecutor, DEFAULT_JOB_CHECK_INTERVAL, DEFAULT_JOB_CHECK_INITIAL_DELAY, DEFAULT_JOB_CHECK_MAX_ATTEMPTS, false);
         return this;
     }
 
     /**
      * Set the options for checking job status<br/>
      * defaults to 1000ms interval, 2000ms initial delay, and 10 max attempts
+     *
      * @see JobCheckOptions
      */
     public ClientBuilder jobCheckOptions(IJobCheckOptions jobCheckOptions) {
@@ -231,13 +235,18 @@ public class ClientBuilder {
                     generateQueueOptions.scheduler(),
                     DEFAULT_JOB_CHECK_INTERVAL,
                     DEFAULT_JOB_CHECK_INITIAL_DELAY,
-                    DEFAULT_JOB_CHECK_MAX_ATTEMPTS
+                    DEFAULT_JOB_CHECK_MAX_ATTEMPTS,
+                    false
             );
         }
 
         RequestHandler requestHandler = requestHandlerConstructor.construct(baseUrl, userAgent, apiKey, timeout, gson);
         RequestExecutors executors = new RequestExecutors(getExecutor, generateExecutor, generateQueueOptions, getQueueOptions, jobCheckOptions);
-        return new MineSkinClientImpl(requestHandler, executors);
+        MineSkinClientImpl client = new MineSkinClientImpl(requestHandler, executors);
+        if (executors.generateQueueOptions() instanceof AutoGenerateQueueOptions autoGenerate) {
+            autoGenerate.setClient(client);
+        }
+        return client;
     }
 
 }

--- a/core/src/main/java/org/mineskin/ClientBuilder.java
+++ b/core/src/main/java/org/mineskin/ClientBuilder.java
@@ -1,6 +1,8 @@
 package org.mineskin;
 
 import com.google.gson.Gson;
+import org.mineskin.options.IJobCheckOptions;
+import org.mineskin.options.IQueueOptions;
 import org.mineskin.request.RequestHandler;
 import org.mineskin.request.RequestHandlerConstructor;
 
@@ -26,9 +28,9 @@ public class ClientBuilder {
     private Gson gson = new Gson();
     private Executor getExecutor = null;
     private Executor generateExecutor = null;
-    private QueueOptions generateQueueOptions = null;
-    private QueueOptions getQueueOptions = null;
-    private JobCheckOptions jobCheckOptions = null;
+    private IQueueOptions generateQueueOptions = null;
+    private IQueueOptions getQueueOptions = null;
+    private IJobCheckOptions jobCheckOptions = null;
     private RequestHandlerConstructor requestHandlerConstructor = null;
 
     private ClientBuilder() {
@@ -102,7 +104,7 @@ public class ClientBuilder {
     /**
      * Set the ScheduledExecutorService for submitting queue jobs
      *
-     * @deprecated use {@link #generateQueueOptions(QueueOptions)} instead
+     * @deprecated use {@link #generateQueueOptions(IQueueOptions)} instead
      */
     @Deprecated
     public ClientBuilder generateRequestScheduler(ScheduledExecutorService scheduledExecutor) {
@@ -113,8 +115,9 @@ public class ClientBuilder {
     /**
      * Set the options for submitting queue jobs<br/>
      * defaults to 200ms interval and 1 concurrent request
+     * @see QueueOptions
      */
-    public ClientBuilder generateQueueOptions(QueueOptions queueOptions) {
+    public ClientBuilder generateQueueOptions(IQueueOptions queueOptions) {
         this.generateQueueOptions = queueOptions;
         return this;
     }
@@ -122,7 +125,7 @@ public class ClientBuilder {
     /**
      * Set the ScheduledExecutorService for get requests, e.g. getting skins
      *
-     * @deprecated use {@link #getQueueOptions(QueueOptions)} instead
+     * @deprecated use {@link #getQueueOptions(IQueueOptions)} instead
      */
     @Deprecated
     public ClientBuilder getRequestScheduler(ScheduledExecutorService scheduledExecutor) {
@@ -133,8 +136,9 @@ public class ClientBuilder {
     /**
      * Set the options for get requests, e.g. getting skins<br/>
      * defaults to 100ms interval and 5 concurrent requests
+     * @see QueueOptions
      */
-    public ClientBuilder getQueueOptions(QueueOptions queueOptions) {
+    public ClientBuilder getQueueOptions(IQueueOptions queueOptions) {
         this.getQueueOptions = queueOptions;
         return this;
     }
@@ -142,7 +146,7 @@ public class ClientBuilder {
     /**
      * Set the ScheduledExecutorService for checking job status
      *
-     * @deprecated use {@link #jobCheckOptions(JobCheckOptions)} instead
+     * @deprecated use {@link #jobCheckOptions(IJobCheckOptions)} instead
      */
     @Deprecated
     public ClientBuilder jobCheckScheduler(ScheduledExecutorService scheduledExecutor) {
@@ -153,8 +157,9 @@ public class ClientBuilder {
     /**
      * Set the options for checking job status<br/>
      * defaults to 1000ms interval, 2000ms initial delay, and 10 max attempts
+     * @see JobCheckOptions
      */
-    public ClientBuilder jobCheckOptions(JobCheckOptions jobCheckOptions) {
+    public ClientBuilder jobCheckOptions(IJobCheckOptions jobCheckOptions) {
         this.jobCheckOptions = jobCheckOptions;
         return this;
     }

--- a/core/src/main/java/org/mineskin/JobCheckOptions.java
+++ b/core/src/main/java/org/mineskin/JobCheckOptions.java
@@ -1,19 +1,150 @@
 package org.mineskin;
 
 import org.mineskin.options.IJobCheckOptions;
+import org.mineskin.request.backoff.RequestInterval;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * @param scheduler Executor service to run the job checks
- * @param intervalMillis Interval in milliseconds between each job check, default is 1000
- * @param initialDelayMillis Initial delay in milliseconds before the first job check, default is 2000
- * @param maxAttempts Maximum number of attempts to check the job status, default is 10
+ * Example:
+ * <pre>
+ *     JobCheckOptions.create()
+ *           .withUseEta()
+ *           .withInterval(RequestInterval.exponential())
+ *           .withMaxAttempts(50)
+ * </pre>
  */
-public record JobCheckOptions(
-        ScheduledExecutorService scheduler,
-        int intervalMillis,
-        int initialDelayMillis,
-        int maxAttempts
-) implements IJobCheckOptions {
+public final class JobCheckOptions implements IJobCheckOptions {
+
+    private final ScheduledExecutorService scheduler;
+    private final RequestInterval interval;
+    private final int initialDelayMillis;
+    private final int maxAttempts;
+    private final boolean useEta;
+
+    /**
+     * @param scheduler   Executor service to run the job checks - this should be a single-threaded scheduler
+     * @param interval    Interval strategy between each request, see {@link RequestInterval}
+     * @param initialDelayMillis Initial delay in milliseconds before the first job check, default is 2000
+     * @param maxAttempts Maximum number of attempts to check the job status, default is 10
+     * @param useEta      Whether to use the estimated completion time provided by the server to schedule the first check, default is false
+     */
+    @Deprecated
+    public JobCheckOptions(
+            ScheduledExecutorService scheduler,
+            RequestInterval interval,
+            int initialDelayMillis,
+            int maxAttempts,
+            boolean useEta
+    ) {
+        this.scheduler = scheduler;
+        this.interval = interval;
+        this.initialDelayMillis = initialDelayMillis;
+        this.maxAttempts = maxAttempts;
+        this.useEta = useEta;
+    }
+
+    /**
+     * @param scheduler          Executor service to run the job checks - this should be a single-threaded scheduler
+     * @param intervalMillis     Interval in milliseconds between each job check, default is 1000
+     * @param initialDelayMillis Initial delay in milliseconds before the first job check, default is 2000
+     * @param maxAttempts        Maximum number of attempts to check the job status, default is 10
+     * @param useEta             Whether to use the estimated completion time provided by the server to schedule the first check, default is false
+     */
+    @Deprecated
+    public JobCheckOptions(
+            ScheduledExecutorService scheduler,
+            int intervalMillis,
+            int initialDelayMillis,
+            int maxAttempts,
+            boolean useEta
+    ) {
+        this.scheduler = scheduler;
+        this.interval = RequestInterval.constant(intervalMillis);
+        this.initialDelayMillis = initialDelayMillis;
+        this.maxAttempts = maxAttempts;
+        this.useEta = useEta;
+    }
+
+    @Deprecated
+    public JobCheckOptions(
+            ScheduledExecutorService scheduler,
+            int intervalMillis,
+            int initialDelayMillis,
+            int maxAttempts
+    ) {
+        this(scheduler, intervalMillis, initialDelayMillis, maxAttempts, false);
+    }
+
+    /**
+     * Creates a JobCheckOptions instance with default values.
+     */
+    public static JobCheckOptions create(ScheduledExecutorService scheduler) {
+        return new JobCheckOptions(
+                scheduler,
+                1000,
+                2000,
+                10,
+                false
+        );
+    }
+
+    /**
+     * Creates a JobCheckOptions instance with default values.
+     */
+    public static JobCheckOptions create() {
+        return create(Executors.newSingleThreadScheduledExecutor());
+    }
+
+    public JobCheckOptions withInterval(RequestInterval interval) {
+        return new JobCheckOptions(scheduler, interval, initialDelayMillis, maxAttempts, useEta);
+    }
+
+    public JobCheckOptions withInitialDelay(int initialDelayMillis) {
+        return new JobCheckOptions(scheduler, interval, initialDelayMillis, maxAttempts, useEta);
+    }
+
+    public JobCheckOptions withMaxAttempts(int maxAttempts) {
+        return new JobCheckOptions(scheduler, interval, initialDelayMillis, maxAttempts, useEta);
+    }
+
+    /**
+     * Sets the option to use the estimated completion time provided by the server to schedule the first check.
+     */
+    public JobCheckOptions withUseEta() {
+        return new JobCheckOptions(scheduler, interval, initialDelayMillis, maxAttempts, true);
+    }
+
+    @Override
+    public ScheduledExecutorService scheduler() {
+        return scheduler;
+    }
+
+    @Override
+    public RequestInterval interval() {
+        return interval;
+    }
+
+    @Deprecated
+    @Override
+    public int intervalMillis() {
+        return interval.getInterval(1);
+    }
+
+    @Override
+    public int initialDelayMillis() {
+        return initialDelayMillis;
+    }
+
+    @Override
+    public int maxAttempts() {
+        return maxAttempts;
+    }
+
+    @Override
+    public boolean useEta() {
+        return useEta;
+    }
+
 }

--- a/core/src/main/java/org/mineskin/JobCheckOptions.java
+++ b/core/src/main/java/org/mineskin/JobCheckOptions.java
@@ -1,5 +1,7 @@
 package org.mineskin;
 
+import org.mineskin.options.IJobCheckOptions;
+
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -13,5 +15,5 @@ public record JobCheckOptions(
         int intervalMillis,
         int initialDelayMillis,
         int maxAttempts
-) {
+) implements IJobCheckOptions {
 }

--- a/core/src/main/java/org/mineskin/JobChecker.java
+++ b/core/src/main/java/org/mineskin/JobChecker.java
@@ -4,6 +4,7 @@ import org.mineskin.data.JobInfo;
 import org.mineskin.data.JobReference;
 import org.mineskin.data.JobStatus;
 import org.mineskin.exception.MineskinException;
+import org.mineskin.options.IJobCheckOptions;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
@@ -28,7 +29,7 @@ public class JobChecker {
         this(client, jobInfo, executor, maxAttempts, initialDelaySeconds, intervalSeconds, TimeUnit.SECONDS);
     }
 
-    public JobChecker(MineSkinClient client, JobInfo jobInfo, JobCheckOptions options) {
+    public JobChecker(MineSkinClient client, JobInfo jobInfo, IJobCheckOptions options) {
         this(client, jobInfo, options.scheduler(), options.maxAttempts(), options.initialDelayMillis(), options.intervalMillis(), TimeUnit.MILLISECONDS);
     }
 

--- a/core/src/main/java/org/mineskin/JobChecker.java
+++ b/core/src/main/java/org/mineskin/JobChecker.java
@@ -5,11 +5,13 @@ import org.mineskin.data.JobReference;
 import org.mineskin.data.JobStatus;
 import org.mineskin.exception.MineskinException;
 import org.mineskin.options.IJobCheckOptions;
+import org.mineskin.request.backoff.RequestInterval;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
 
 public class JobChecker {
 
@@ -22,36 +24,71 @@ public class JobChecker {
     private final AtomicInteger attempts = new AtomicInteger(0);
     private final int maxAttempts;
     private final int initialDelay;
-    private final int interval;
+    private final RequestInterval interval;
     private final TimeUnit timeUnit;
+    private final boolean useEta;
 
+    public JobChecker(MineSkinClient client, JobInfo jobInfo, IJobCheckOptions options) {
+        this.client = client;
+        this.jobInfo = jobInfo;
+        this.executor = options.scheduler();
+        this.maxAttempts = options.maxAttempts();
+        this.initialDelay = options.initialDelayMillis();
+        this.interval = options.interval();
+        this.timeUnit = TimeUnit.MILLISECONDS;
+        this.useEta = options.useEta();
+    }
+
+    @Deprecated
     public JobChecker(MineSkinClient client, JobInfo jobInfo, ScheduledExecutorService executor, int maxAttempts, int initialDelaySeconds, int intervalSeconds) {
         this(client, jobInfo, executor, maxAttempts, initialDelaySeconds, intervalSeconds, TimeUnit.SECONDS);
     }
 
-    public JobChecker(MineSkinClient client, JobInfo jobInfo, IJobCheckOptions options) {
-        this(client, jobInfo, options.scheduler(), options.maxAttempts(), options.initialDelayMillis(), options.intervalMillis(), TimeUnit.MILLISECONDS);
+    @Deprecated
+    public JobChecker(MineSkinClient client, JobInfo jobInfo, ScheduledExecutorService executor, int maxAttempts, int initialDelay, int interval, TimeUnit timeUnit) {
+        this(client, jobInfo, executor, maxAttempts, initialDelay, interval, timeUnit, false);
     }
 
-    public JobChecker(MineSkinClient client, JobInfo jobInfo, ScheduledExecutorService executor, int maxAttempts, int initialDelay, int interval, TimeUnit timeUnit) {
+    @Deprecated
+    public JobChecker(MineSkinClient client, JobInfo jobInfo, ScheduledExecutorService executor, int maxAttempts, int initialDelay, int interval, TimeUnit timeUnit, boolean useEta) {
         this.client = client;
         this.jobInfo = jobInfo;
         this.executor = executor;
         this.maxAttempts = maxAttempts;
-        this.initialDelay = initialDelay;
-        this.interval = interval;
+        this.initialDelay = (int) timeUnit.toMillis(initialDelay);
+        this.interval = RequestInterval.constant((int) timeUnit.toMillis(interval));
         this.timeUnit = timeUnit;
+        this.useEta = useEta;
     }
 
+    /**
+     * Starts checking the job status. Only call this once.
+     *
+     * @return A future that completes when the job is completed or failed, or exceptionally if an error occurs or max attempts is reached.
+     */
     public CompletableFuture<JobReference> check() {
         future = new CompletableFuture<>();
+
+        // Try to use the ETA to schedule the first check
+        if (useEta && jobInfo.eta() > 1) {
+            long delay = jobInfo.eta() - System.currentTimeMillis();
+            if (delay > 0) {
+                client.getLogger().log(Level.FINER, "Scheduling first job check in {0}ms based on ETA", delay);
+                executor.schedule(this::checkJob, delay, TimeUnit.MILLISECONDS);
+                return future;
+            }
+        }
+
+        // or just use the initial delay
         executor.schedule(this::checkJob, initialDelay, timeUnit);
+
         return future;
     }
 
     private void checkJob() {
-        if (attempts.incrementAndGet() > maxAttempts) {
-            future.completeExceptionally(new MineskinException("Max attempts reached"));
+        int attempt = attempts.incrementAndGet();
+        if (attempt > maxAttempts) {
+            future.completeExceptionally(new MineskinException("Max attempts reached").withBreadcrumb(jobInfo.getBreadcrumb()));
             return;
         }
         client.queue().get(jobInfo)
@@ -59,11 +96,12 @@ public class JobChecker {
                     JobInfo info = response.getBody();
                     if (info != null) {
                         jobInfo = info;
+//                        client.getLogger().log(Level.FINER, "ETA {0} {1}", new Object[]{info.eta(), info.getBreadcrumb()});
                     }
                     if (jobInfo.status() == JobStatus.COMPLETED || jobInfo.status() == JobStatus.FAILED) {
                         future.complete(response);
                     } else {
-                        executor.schedule(this::checkJob, interval, timeUnit);
+                        executor.schedule(this::checkJob, interval.getInterval(attempt), timeUnit);
                     }
                 })
                 .exceptionally(throwable -> {

--- a/core/src/main/java/org/mineskin/MineSkinClient.java
+++ b/core/src/main/java/org/mineskin/MineSkinClient.java
@@ -1,5 +1,7 @@
 package org.mineskin;
 
+import java.util.logging.Logger;
+
 public interface MineSkinClient {
 
     static ClientBuilder builder() {
@@ -25,5 +27,7 @@ public interface MineSkinClient {
      * Get the client for miscellaneous endpoints
      */
     MiscClient misc();
+
+    Logger getLogger();
 
 }

--- a/core/src/main/java/org/mineskin/MineSkinClient.java
+++ b/core/src/main/java/org/mineskin/MineSkinClient.java
@@ -21,4 +21,9 @@ public interface MineSkinClient {
      */
     SkinsClient skins();
 
+    /**
+     * Get the client for miscellaneous endpoints
+     */
+    MiscClient misc();
+
 }

--- a/core/src/main/java/org/mineskin/MineSkinClientImpl.java
+++ b/core/src/main/java/org/mineskin/MineSkinClientImpl.java
@@ -33,6 +33,7 @@ public class MineSkinClientImpl implements MineSkinClient {
     private final QueueClient queueClient = new QueueClientImpl();
     private final GenerateClient generateClient = new GenerateClientImpl();
     private final SkinsClient skinsClient = new SkinsClientImpl();
+    private final MiscClient miscClient = new MiscClientImpl();
 
     public MineSkinClientImpl(RequestHandler requestHandler, RequestExecutors executors) {
         this.requestHandler = checkNotNull(requestHandler);
@@ -58,6 +59,11 @@ public class MineSkinClientImpl implements MineSkinClient {
     @Override
     public SkinsClient skins() {
         return skinsClient;
+    }
+
+    @Override
+    public MiscClient misc() {
+        return miscClient;
     }
 
     class QueueClientImpl implements QueueClient {
@@ -296,6 +302,19 @@ public class MineSkinClientImpl implements MineSkinClient {
             }, executors.getExecutor());
         }
 
+    }
+
+    class MiscClientImpl implements MiscClient {
+        @Override
+        public CompletableFuture<UserResponse> getUser() {
+            return getQueue.submit(() -> {
+                try {
+                    return requestHandler.getJson("/v2/me", UserInfo.class, UserResponseImpl::new);
+                } catch (IOException e) {
+                    throw new MineskinException(e);
+                }
+            }, executors.getExecutor());
+        }
     }
 
 }

--- a/core/src/main/java/org/mineskin/MineSkinClientImpl.java
+++ b/core/src/main/java/org/mineskin/MineSkinClientImpl.java
@@ -43,6 +43,11 @@ public class MineSkinClientImpl implements MineSkinClient {
         this.getQueue = new RequestQueue(executors.getQueueOptions());
     }
 
+    @Override
+    public Logger getLogger() {
+        return LOGGER;
+    }
+
     /// //
 
 

--- a/core/src/main/java/org/mineskin/MineSkinClientImpl.java
+++ b/core/src/main/java/org/mineskin/MineSkinClientImpl.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -73,12 +74,14 @@ public class MineSkinClientImpl implements MineSkinClient {
         }
 
         CompletableFuture<QueueResponse> queueUpload(UploadRequestBuilder builder) {
+            LOGGER.log(Level.FINER, "Adding upload request to internal queue: {0}", builder);
             return generateQueue.submit(() -> {
                 try {
                     Map<String, String> data = builder.options().toMap();
                     UploadSource source = builder.getUploadSource();
                     checkNotNull(source);
                     try (InputStream inputStream = source.getInputStream()) {
+                        LOGGER.log(Level.FINER, "Submitting to MineSkin queue: {0}", builder);
                         QueueResponseImpl res = requestHandler.postFormDataFile("/v2/queue", "file", "mineskinjava", inputStream, data, JobInfo.class, QueueResponseImpl::new);
                         handleGenerateResponse(res);
                         return res;
@@ -93,12 +96,14 @@ public class MineSkinClientImpl implements MineSkinClient {
         }
 
         CompletableFuture<QueueResponse> queueUrl(UrlRequestBuilder builder) {
+            LOGGER.log(Level.FINER, "Adding url request to internal queue: {0}", builder);
             return generateQueue.submit(() -> {
                 try {
                     JsonObject body = builder.options().toJson();
                     URL url = builder.getUrl();
                     checkNotNull(url);
                     body.addProperty("url", url.toString());
+                    LOGGER.log(Level.FINER, "Submitting to MineSkin queue: {0}", builder);
                     QueueResponseImpl res = requestHandler.postJson("/v2/queue", body, JobInfo.class, QueueResponseImpl::new);
                     handleGenerateResponse(res);
                     return res;
@@ -112,12 +117,14 @@ public class MineSkinClientImpl implements MineSkinClient {
         }
 
         CompletableFuture<QueueResponse> queueUser(UserRequestBuilder builder) {
+            LOGGER.log(Level.FINER, "Adding user request to internal queue: {0}", builder);
             return generateQueue.submit(() -> {
                 try {
                     JsonObject body = builder.options().toJson();
                     UUID uuid = builder.getUuid();
                     checkNotNull(uuid);
                     body.addProperty("user", uuid.toString());
+                    LOGGER.log(Level.FINER, "Submitting to MineSkin queue: {0}", builder);
                     QueueResponseImpl res = requestHandler.postJson("/v2/queue", body, JobInfo.class, QueueResponseImpl::new);
                     handleGenerateResponse(res);
                     return res;
@@ -186,12 +193,14 @@ public class MineSkinClientImpl implements MineSkinClient {
         }
 
         CompletableFuture<GenerateResponse> generateUpload(UploadRequestBuilder builder) {
+            LOGGER.log(Level.FINER, "Adding upload request to internal generate queue: {0}", builder);
             return generateQueue.submit(() -> {
                 try {
                     Map<String, String> data = builder.options().toMap();
                     UploadSource source = builder.getUploadSource();
                     checkNotNull(source);
                     try (InputStream inputStream = source.getInputStream()) {
+                        LOGGER.log(Level.FINER, "Submitting to MineSkin generate: {0}", builder);
                         GenerateResponseImpl res = requestHandler.postFormDataFile("/v2/generate", "file", "mineskinjava", inputStream, data, SkinInfo.class, GenerateResponseImpl::new);
                         handleGenerateResponse(res);
                         return res;
@@ -206,12 +215,14 @@ public class MineSkinClientImpl implements MineSkinClient {
         }
 
         CompletableFuture<GenerateResponse> generateUrl(UrlRequestBuilder builder) {
+            LOGGER.log(Level.FINER, "Adding url request to internal generate queue: {0}", builder);
             return generateQueue.submit(() -> {
                 try {
                     JsonObject body = builder.options().toJson();
                     URL url = builder.getUrl();
                     checkNotNull(url);
                     body.addProperty("url", url.toString());
+                    LOGGER.log(Level.FINER, "Submitting to MineSkin generate: {0}", builder);
                     GenerateResponseImpl res = requestHandler.postJson("/v2/generate", body, SkinInfo.class, GenerateResponseImpl::new);
                     handleGenerateResponse(res);
                     return res;
@@ -225,12 +236,14 @@ public class MineSkinClientImpl implements MineSkinClient {
         }
 
         CompletableFuture<GenerateResponse> generateUser(UserRequestBuilder builder) {
+            LOGGER.log(Level.FINER, "Adding user request to internal generate queue: {0}", builder);
             return generateQueue.submit(() -> {
                 try {
                     JsonObject body = builder.options().toJson();
                     UUID uuid = builder.getUuid();
                     checkNotNull(uuid);
                     body.addProperty("user", uuid.toString());
+                    LOGGER.log(Level.FINER, "Submitting to MineSkin generate: {0}", builder);
                     GenerateResponseImpl res = requestHandler.postJson("/v2/generate", body, SkinInfo.class, GenerateResponseImpl::new);
                     handleGenerateResponse(res);
                     return res;
@@ -244,6 +257,7 @@ public class MineSkinClientImpl implements MineSkinClient {
         }
 
         private void handleGenerateResponse(MineSkinResponse<?> response0) {
+            LOGGER.log(Level.FINER, "Handling generate response: {0}", response0);
             if (!(response0 instanceof GenerateResponse response)) return;
             RateLimitInfo rateLimit = response.getRateLimit();
             if (rateLimit == null) return;

--- a/core/src/main/java/org/mineskin/MineSkinClientImpl.java
+++ b/core/src/main/java/org/mineskin/MineSkinClientImpl.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import org.mineskin.data.*;
 import org.mineskin.exception.MineSkinRequestException;
 import org.mineskin.exception.MineskinException;
+import org.mineskin.options.IJobCheckOptions;
 import org.mineskin.request.*;
 import org.mineskin.request.source.UploadSource;
 import org.mineskin.response.*;
@@ -171,7 +172,7 @@ public class MineSkinClientImpl implements MineSkinClient {
             if (jobInfo.id() == null) {
                 return CompletableFuture.completedFuture(new NullJobReference(jobInfo));
             }
-            JobCheckOptions options = executors.jobCheckOptions();
+            IJobCheckOptions options = executors.jobCheckOptions();
             return new JobChecker(MineSkinClientImpl.this, jobInfo, options).check();
         }
 

--- a/core/src/main/java/org/mineskin/MiscClient.java
+++ b/core/src/main/java/org/mineskin/MiscClient.java
@@ -1,0 +1,13 @@
+package org.mineskin;
+
+import org.mineskin.response.UserResponse;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface MiscClient {
+    /**
+     * Get the current user
+     * @see <a href="https://docs.mineskin.org/docs/mineskin-api/get-the-current-user">Get the current user</a>
+     */
+    CompletableFuture<UserResponse> getUser();
+}

--- a/core/src/main/java/org/mineskin/QueueOptions.java
+++ b/core/src/main/java/org/mineskin/QueueOptions.java
@@ -1,17 +1,75 @@
 package org.mineskin;
 
+import org.mineskin.options.AutoGenerateQueueOptions;
 import org.mineskin.options.IQueueOptions;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
- * @param scheduler Executor service to run the queue
+ * @param scheduler      Executor service to run the queue - this should be a single-threaded scheduler
  * @param intervalMillis Interval in milliseconds between each request
- * @param concurrency Maximum number of concurrent requests
+ * @param concurrency    Maximum number of concurrent requests
  */
 public record QueueOptions(
         ScheduledExecutorService scheduler,
         int intervalMillis,
         int concurrency
 ) implements IQueueOptions {
+
+    /**
+     * Creates a QueueOptions instance with default values for generate requests (200ms interval, 1 concurrent request).
+     */
+    public static QueueOptions createGenerate(ScheduledExecutorService scheduler) {
+        return new QueueOptions(scheduler, 200, 1);
+    }
+
+    /**
+     * Creates a QueueOptions instance with default values for generate requests (200ms interval, 1 concurrent request).
+     */
+    public static QueueOptions createGenerate() {
+        return createGenerate(Executors.newSingleThreadScheduledExecutor());
+    }
+
+    /**
+     * Creates a QueueOptions instance that automatically adjusts the interval and concurrency based on the user's allowance.
+     *
+     * @see AutoGenerateQueueOptions
+     */
+    public static AutoGenerateQueueOptions createAutoGenerate(ScheduledExecutorService scheduler) {
+        return new AutoGenerateQueueOptions(scheduler);
+    }
+
+    /**
+     * Creates a QueueOptions instance that automatically adjusts the interval and concurrency based on the user's allowance.
+     *
+     * @see AutoGenerateQueueOptions
+     */
+    public static AutoGenerateQueueOptions createAutoGenerate() {
+        return createAutoGenerate(Executors.newSingleThreadScheduledExecutor());
+    }
+
+    /**
+     * Creates a QueueOptions instance with default values for get requests (100ms interval, 5 concurrent requests).
+     */
+    public static QueueOptions createGet(ScheduledExecutorService scheduler) {
+        return new QueueOptions(scheduler, 100, 5);
+    }
+
+    /**
+     * Creates a QueueOptions instance with default values for get requests (100ms interval, 5 concurrent requests).
+     */
+    public static QueueOptions createGet() {
+        return createGet(Executors.newSingleThreadScheduledExecutor());
+    }
+
+    public QueueOptions withInterval(int interval, TimeUnit unit) {
+        return new QueueOptions(scheduler, (int) unit.toMillis(interval), concurrency);
+    }
+
+    public QueueOptions withConcurrency(int concurrency) {
+        return new QueueOptions(scheduler, intervalMillis, concurrency);
+    }
+
 }

--- a/core/src/main/java/org/mineskin/QueueOptions.java
+++ b/core/src/main/java/org/mineskin/QueueOptions.java
@@ -1,5 +1,7 @@
 package org.mineskin;
 
+import org.mineskin.options.IQueueOptions;
+
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -11,5 +13,5 @@ public record QueueOptions(
         ScheduledExecutorService scheduler,
         int intervalMillis,
         int concurrency
-) {
+) implements IQueueOptions {
 }

--- a/core/src/main/java/org/mineskin/RequestExecutors.java
+++ b/core/src/main/java/org/mineskin/RequestExecutors.java
@@ -1,12 +1,15 @@
 package org.mineskin;
 
+import org.mineskin.options.IJobCheckOptions;
+import org.mineskin.options.IQueueOptions;
+
 import java.util.concurrent.Executor;
 
 public record RequestExecutors(
     Executor getExecutor,
     Executor generateExecutor,
-    QueueOptions generateQueueOptions,
-    QueueOptions getQueueOptions,
-    JobCheckOptions jobCheckOptions
+    IQueueOptions generateQueueOptions,
+    IQueueOptions getQueueOptions,
+    IJobCheckOptions jobCheckOptions
 ) {
 }

--- a/core/src/main/java/org/mineskin/RequestQueue.java
+++ b/core/src/main/java/org/mineskin/RequestQueue.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 public class RequestQueue {
 
@@ -22,13 +23,16 @@ public class RequestQueue {
     public RequestQueue(ScheduledExecutorService executor, int interval, int concurrency) {
         executor.scheduleAtFixedRate(() -> {
             if (System.currentTimeMillis() < nextRequest) {
+                MineSkinClientImpl.LOGGER.log(Level.FINER, "Waiting for next request in {0}ms ({1})", new Object[]{nextRequest - System.currentTimeMillis(), hashCode()});
                 return;
             }
             if (running.get() >= concurrency) {
+                MineSkinClientImpl.LOGGER.log(Level.FINER, "Skipping request, already running {0} tasks", running.get());
                 return;
             }
             Supplier<CompletableFuture<?>> supplier;
             if ((supplier = queue.poll()) != null) {
+                MineSkinClientImpl.LOGGER.log(Level.FINER, "Processing request, running {0} tasks", running.get());
                 running.incrementAndGet();
                 supplier.get();
             }

--- a/core/src/main/java/org/mineskin/RequestQueue.java
+++ b/core/src/main/java/org/mineskin/RequestQueue.java
@@ -16,29 +16,61 @@ public class RequestQueue {
 
     private final Queue<Supplier<CompletableFuture<?>>> queue = new LinkedList<>();
     private final AtomicInteger running = new AtomicInteger(0);
+
+    private final ScheduledExecutorService executor;
+    private final Supplier<Integer> interval;
+    private final Supplier<Integer> concurrency;
+
     private long nextRequest = 0;
 
     public RequestQueue(IQueueOptions options) {
-        this(options.scheduler(), options.intervalMillis(), options.concurrency());
+        this(options.scheduler(), options::intervalMillis, options::concurrency);
     }
 
     public RequestQueue(ScheduledExecutorService executor, int interval, int concurrency) {
-        executor.scheduleAtFixedRate(() -> {
-            if (System.currentTimeMillis() < nextRequest) {
-                MineSkinClientImpl.LOGGER.log(Level.FINER, "Waiting for next request in {0}ms ({1})", new Object[]{nextRequest - System.currentTimeMillis(), hashCode()});
-                return;
-            }
-            if (running.get() >= concurrency) {
-                MineSkinClientImpl.LOGGER.log(Level.FINER, "Skipping request, already running {0} tasks", running.get());
-                return;
-            }
-            Supplier<CompletableFuture<?>> supplier;
-            if ((supplier = queue.poll()) != null) {
-                MineSkinClientImpl.LOGGER.log(Level.FINER, "Processing request, running {0} tasks", running.get());
-                running.incrementAndGet();
-                supplier.get();
-            }
-        }, 0, interval, TimeUnit.MILLISECONDS);
+        this(executor, () -> interval, () -> concurrency);
+    }
+
+    public RequestQueue(ScheduledExecutorService executor, Supplier<Integer> interval, Supplier<Integer> concurrency) {
+        this.executor = executor;
+        this.interval = interval;
+        this.concurrency = concurrency;
+
+        tickAndSchedule();
+    }
+
+    private void tickAndSchedule() {
+        try {
+            tick();
+        } catch (Throwable throwable) {
+            MineSkinClientImpl.LOGGER.log(Level.SEVERE, "Error in request queue tick", throwable);
+        }
+        executor.schedule(this::tickAndSchedule, interval.get(), TimeUnit.MILLISECONDS);
+    }
+
+    private void tick() {
+        if (System.currentTimeMillis() < nextRequest) {
+            MineSkinClientImpl.LOGGER.log(Level.FINER, "Waiting for next request in {0}ms ({1})", new Object[]{nextRequest - System.currentTimeMillis(), hashCode()});
+            return;
+        }
+        if (running.get() >= concurrency.get()) {
+            MineSkinClientImpl.LOGGER.log(Level.FINER, "Skipping request, already running {0} tasks", running.get());
+            return;
+        }
+        Supplier<CompletableFuture<?>> supplier;
+        if ((supplier = queue.poll()) != null) {
+            MineSkinClientImpl.LOGGER.log(Level.FINER, "Processing request, running {0} tasks", running.get());
+            running.incrementAndGet();
+            supplier.get();
+        }
+    }
+
+    public int getInterval() {
+        return interval.get();
+    }
+
+    public int getConcurrency() {
+        return concurrency.get();
     }
 
     public void setNextRequest(long nextRequest) {

--- a/core/src/main/java/org/mineskin/RequestQueue.java
+++ b/core/src/main/java/org/mineskin/RequestQueue.java
@@ -1,5 +1,7 @@
 package org.mineskin;
 
+import org.mineskin.options.IQueueOptions;
+
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -16,7 +18,7 @@ public class RequestQueue {
     private final AtomicInteger running = new AtomicInteger(0);
     private long nextRequest = 0;
 
-    public RequestQueue(QueueOptions options) {
+    public RequestQueue(IQueueOptions options) {
         this(options.scheduler(), options.intervalMillis(), options.concurrency());
     }
 

--- a/core/src/main/java/org/mineskin/data/Breadcrumbed.java
+++ b/core/src/main/java/org/mineskin/data/Breadcrumbed.java
@@ -1,0 +1,8 @@
+package org.mineskin.data;
+
+import javax.annotation.Nullable;
+
+public interface Breadcrumbed {
+    @Nullable
+    String getBreadcrumb();
+}

--- a/core/src/main/java/org/mineskin/data/CreditsUsageInfo.java
+++ b/core/src/main/java/org/mineskin/data/CreditsUsageInfo.java
@@ -1,4 +1,5 @@
 package org.mineskin.data;
 
+@Deprecated
 public record CreditsUsageInfo(int used, int remaining) {
 }

--- a/core/src/main/java/org/mineskin/data/Grants.java
+++ b/core/src/main/java/org/mineskin/data/Grants.java
@@ -1,0 +1,51 @@
+package org.mineskin.data;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.Optional;
+
+public class Grants {
+
+    private final JsonObject raw;
+
+    public Grants(JsonObject raw) {
+        this.raw = raw;
+    }
+
+    public Optional<JsonElement> getRaw(String key) {
+        if (raw.has(key) && !raw.get(key).isJsonNull()) {
+            return Optional.of(raw.get(key));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<Boolean> getBoolean(String key) {
+        return getRaw(key).map(JsonElement::getAsBoolean);
+    }
+
+    public Optional<Integer> getInt(String key) {
+        return getRaw(key).map(JsonElement::getAsInt);
+    }
+
+    public Optional<Double> getDouble(String key) {
+        return getRaw(key).map(JsonElement::getAsDouble);
+    }
+
+    public Optional<String> getString(String key) {
+        return getRaw(key).map(JsonElement::getAsString);
+    }
+
+    public Optional<Integer> perMinute() {
+        return getInt("per_minute");
+    }
+
+    public Optional<Integer> concurrency() {
+        return getInt("concurrency");
+    }
+
+    @Override
+    public String toString() {
+        return "Grants" + raw;
+    }
+}

--- a/core/src/main/java/org/mineskin/data/MutableBreadcrumbed.java
+++ b/core/src/main/java/org/mineskin/data/MutableBreadcrumbed.java
@@ -1,0 +1,5 @@
+package org.mineskin.data;
+
+public interface MutableBreadcrumbed extends Breadcrumbed {
+    void setBreadcrumb(String breadcrumb);
+}

--- a/core/src/main/java/org/mineskin/data/SkinInfo.java
+++ b/core/src/main/java/org/mineskin/data/SkinInfo.java
@@ -1,6 +1,8 @@
 package org.mineskin.data;
 
-public class SkinInfo implements Skin {
+import javax.annotation.Nullable;
+
+public class SkinInfo implements Skin, MutableBreadcrumbed {
 
     private final String uuid;
     private final String name;
@@ -11,6 +13,8 @@ public class SkinInfo implements Skin {
 
     private final int views;
     private final boolean duplicate;
+
+    private String breadcrumb;
 
     public SkinInfo(String uuid, String name, Variant variant, Visibility visibility, TextureInfo texture, GeneratorInfo generator, int views, boolean duplicate) {
         this.uuid = uuid;
@@ -62,6 +66,17 @@ public class SkinInfo implements Skin {
         return duplicate;
     }
 
+    @Nullable
+    @Override
+    public String getBreadcrumb() {
+        return breadcrumb;
+    }
+
+    @Override
+    public void setBreadcrumb(String breadcrumb) {
+        this.breadcrumb = breadcrumb;
+    }
+
     @Override
     public String toString() {
         return "SkinInfo{" +
@@ -73,6 +88,7 @@ public class SkinInfo implements Skin {
                 ", generator=" + generator +
                 ", views=" + views +
                 ", duplicate=" + duplicate +
+                ", breadcrumb='" + breadcrumb + '\'' +
                 '}';
     }
 }

--- a/core/src/main/java/org/mineskin/data/User.java
+++ b/core/src/main/java/org/mineskin/data/User.java
@@ -1,0 +1,7 @@
+package org.mineskin.data;
+
+public interface User {
+    String uuid();
+
+    Grants grants();
+}

--- a/core/src/main/java/org/mineskin/data/UserInfo.java
+++ b/core/src/main/java/org/mineskin/data/UserInfo.java
@@ -1,0 +1,43 @@
+package org.mineskin.data;
+
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+
+public class UserInfo implements User {
+
+    @SerializedName("user")
+    private final String uuid;
+    private final JsonObject grants;
+
+    private Grants grantsWrapper;
+
+    public UserInfo(String uuid, JsonObject grants) {
+        this.uuid = uuid;
+        this.grants = grants;
+    }
+
+    @Override
+    public String uuid() {
+        return uuid;
+    }
+
+    public JsonObject rawGrants() {
+        return grants;
+    }
+
+    @Override
+    public Grants grants() {
+        if (grantsWrapper == null) {
+            grantsWrapper = new Grants(grants);
+        }
+        return grantsWrapper;
+    }
+
+    @Override
+    public String toString() {
+        return "UserInfo{" +
+                "uuid='" + uuid + '\'' +
+                ", grants=" + grants() +
+                '}';
+    }
+}

--- a/core/src/main/java/org/mineskin/exception/IBreadcrumbException.java
+++ b/core/src/main/java/org/mineskin/exception/IBreadcrumbException.java
@@ -1,0 +1,6 @@
+package org.mineskin.exception;
+
+import org.mineskin.data.Breadcrumbed;
+
+public interface IBreadcrumbException extends Breadcrumbed {
+}

--- a/core/src/main/java/org/mineskin/exception/MineSkinRequestException.java
+++ b/core/src/main/java/org/mineskin/exception/MineSkinRequestException.java
@@ -2,7 +2,7 @@ package org.mineskin.exception;
 
 import org.mineskin.response.MineSkinResponse;
 
-public class MineSkinRequestException extends RuntimeException {
+public class MineSkinRequestException extends RuntimeException implements IBreadcrumbException  {
 
     private final String code;
     private final MineSkinResponse<?> response;
@@ -22,4 +22,11 @@ public class MineSkinRequestException extends RuntimeException {
     public MineSkinResponse<?> getResponse() {
         return response;
     }
+
+    @Override
+    public String getBreadcrumb() {
+        if (response == null) return null;
+        return response.getBreadcrumb();
+    }
+
 }

--- a/core/src/main/java/org/mineskin/exception/MineskinException.java
+++ b/core/src/main/java/org/mineskin/exception/MineskinException.java
@@ -1,6 +1,11 @@
 package org.mineskin.exception;
 
-public class MineskinException extends RuntimeException {
+import javax.annotation.Nullable;
+
+public class MineskinException extends RuntimeException implements IBreadcrumbException {
+
+    private String breadcrumb;
+
     public MineskinException() {
     }
 
@@ -19,4 +24,16 @@ public class MineskinException extends RuntimeException {
     public MineskinException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
+
+    public MineskinException withBreadcrumb(String breadcrumb) {
+        this.breadcrumb = breadcrumb;
+        return this;
+    }
+
+    @Nullable
+    @Override
+    public String getBreadcrumb() {
+        return breadcrumb;
+    }
+
 }

--- a/core/src/main/java/org/mineskin/options/AutoGenerateQueueOptions.java
+++ b/core/src/main/java/org/mineskin/options/AutoGenerateQueueOptions.java
@@ -1,0 +1,105 @@
+package org.mineskin.options;
+
+import org.mineskin.MineSkinClient;
+import org.mineskin.MineSkinClientImpl;
+import org.mineskin.data.User;
+import org.mineskin.response.UserResponse;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+
+public class AutoGenerateQueueOptions implements IQueueOptions {
+
+    private static final int MIN_INTERVAL_MILLIS = 100;
+    private static final int MAX_INTERVAL_MILLIS = 1000;
+    private static final int MIN_CONCURRENCY = 1;
+    private static final int MAX_CONCURRENCY = 30;
+
+    private final ScheduledExecutorService scheduler;
+    private MineSkinClient client;
+
+    private final AtomicLong lastRefresh = new AtomicLong(0);
+
+    private final AtomicInteger intervalMillis = new AtomicInteger(MAX_INTERVAL_MILLIS);
+    private final AtomicInteger concurrency = new AtomicInteger(MIN_INTERVAL_MILLIS);
+
+    public AutoGenerateQueueOptions(
+            ScheduledExecutorService scheduler
+    ) {
+        this.scheduler = scheduler;
+    }
+
+    public AutoGenerateQueueOptions() {
+        this(Executors.newSingleThreadScheduledExecutor());
+    }
+
+
+    public void setClient(MineSkinClient client) {
+        this.client = client;
+        // Initial load
+        reloadGrants().exceptionally(throwable -> {
+            MineSkinClientImpl.LOGGER.log(Level.WARNING, "Failed to load grants", throwable);
+            return null;
+        });
+    }
+
+    @Override
+    public ScheduledExecutorService scheduler() {
+        return scheduler;
+    }
+
+    @Override
+    public int intervalMillis() {
+        reloadIfNeeded();
+        return intervalMillis.get();
+    }
+
+    @Override
+    public int concurrency() {
+        reloadIfNeeded();
+        return concurrency.get();
+    }
+
+    private void reloadIfNeeded() {
+        long now = System.currentTimeMillis();
+        if (now - lastRefresh.get() > TimeUnit.MINUTES.toMillis(5)) { // 5 minutes
+            reloadGrants().exceptionally(throwable -> {
+                MineSkinClientImpl.LOGGER.log(Level.WARNING, "Failed to reload grants", throwable);
+                return null;
+            });
+        }
+    }
+
+    public CompletableFuture<Void> reloadGrants() {
+        if (client == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        lastRefresh.set(System.currentTimeMillis());
+
+        return client.misc().getUser()
+                .thenApply(UserResponse::getUser)
+                .thenApply(User::grants)
+                .thenAccept(grants -> {
+                    grants.concurrency().ifPresent(rawConcurrent -> {
+                        int concurrent = Math.min(Math.max(rawConcurrent, MIN_CONCURRENCY), MAX_CONCURRENCY);
+                        int previous = concurrency.getAndSet(concurrent);
+                        if (previous != rawConcurrent) {
+                            client.getLogger().log(Level.FINE, "[QueueOptions] Updated concurrency from {0} to {1}", new Object[]{previous, concurrent});
+                        }
+                    });
+                    grants.perMinute().ifPresent(rawPerMinute -> {
+                        int interval = Math.min(Math.max(60_000 / rawPerMinute, MIN_INTERVAL_MILLIS), MAX_INTERVAL_MILLIS);
+                        int previous = intervalMillis.getAndSet(interval);
+                        if (previous != interval) {
+                            client.getLogger().log(Level.FINE, "[QueueOptions] Updated interval from {0}ms to {1}ms (perMinute={2})", new Object[]{previous, interval, rawPerMinute});
+                        }
+                    });
+                });
+    }
+
+}

--- a/core/src/main/java/org/mineskin/options/IJobCheckOptions.java
+++ b/core/src/main/java/org/mineskin/options/IJobCheckOptions.java
@@ -1,0 +1,16 @@
+package org.mineskin.options;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Base implementation: {@link org.mineskin.JobCheckOptions}
+ */
+public interface IJobCheckOptions {
+    ScheduledExecutorService scheduler();
+
+    int intervalMillis();
+
+    int initialDelayMillis();
+
+    int maxAttempts();
+}

--- a/core/src/main/java/org/mineskin/options/IJobCheckOptions.java
+++ b/core/src/main/java/org/mineskin/options/IJobCheckOptions.java
@@ -1,5 +1,7 @@
 package org.mineskin.options;
 
+import org.mineskin.request.backoff.RequestInterval;
+
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -8,9 +10,14 @@ import java.util.concurrent.ScheduledExecutorService;
 public interface IJobCheckOptions {
     ScheduledExecutorService scheduler();
 
+    RequestInterval interval();
+
+    @Deprecated
     int intervalMillis();
 
     int initialDelayMillis();
 
     int maxAttempts();
+
+    boolean useEta();
 }

--- a/core/src/main/java/org/mineskin/options/IQueueOptions.java
+++ b/core/src/main/java/org/mineskin/options/IQueueOptions.java
@@ -1,0 +1,14 @@
+package org.mineskin.options;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Base implementation: {@link org.mineskin.QueueOptions}
+ */
+public interface IQueueOptions {
+    ScheduledExecutorService scheduler();
+
+    int intervalMillis();
+
+    int concurrency();
+}

--- a/core/src/main/java/org/mineskin/request/backoff/ExponentialBackoff.java
+++ b/core/src/main/java/org/mineskin/request/backoff/ExponentialBackoff.java
@@ -1,0 +1,63 @@
+package org.mineskin.request.backoff;
+
+public final class ExponentialBackoff implements RequestInterval {
+
+    private final int initialDelayMillis;
+    private final int maxDelayMillis;
+    private final double multiplier;
+    private final int freeAttempts;
+
+    ExponentialBackoff(
+            int initialDelayMillis,
+            int maxDelayMillis,
+            double multiplier,
+            int freeAttempts
+    ) {
+        this.initialDelayMillis = initialDelayMillis;
+        this.maxDelayMillis = maxDelayMillis;
+        this.multiplier = multiplier;
+        this.freeAttempts = freeAttempts;
+    }
+
+    public ExponentialBackoff withInitialDelay(int initialDelayMillis) {
+        return new ExponentialBackoff(initialDelayMillis, this.maxDelayMillis, this.multiplier, this.freeAttempts);
+    }
+
+    public ExponentialBackoff withMaxDelay(int maxDelayMillis) {
+        return new ExponentialBackoff(this.initialDelayMillis, maxDelayMillis, this.multiplier, this.freeAttempts);
+    }
+
+    public ExponentialBackoff withMultiplier(double multiplier) {
+        return new ExponentialBackoff(this.initialDelayMillis, this.maxDelayMillis, multiplier, this.freeAttempts);
+    }
+
+    public ExponentialBackoff withFreeAttempts(int freeAttempts) {
+        return new ExponentialBackoff(this.initialDelayMillis, this.maxDelayMillis, this.multiplier, freeAttempts);
+    }
+
+    @Override
+    public int getInterval(int attempt) {
+        if (attempt <= freeAttempts) {
+            return initialDelayMillis;
+        }
+        double delay = initialDelayMillis * Math.pow(multiplier, Math.max(0, attempt - freeAttempts));
+        return (int) Math.min(delay, maxDelayMillis);
+    }
+
+    public int initialDelayMillis() {
+        return initialDelayMillis;
+    }
+
+    public int maxDelayMillis() {
+        return maxDelayMillis;
+    }
+
+    public double multiplier() {
+        return multiplier;
+    }
+
+    public int freeAttempts() {
+        return freeAttempts;
+    }
+
+}

--- a/core/src/main/java/org/mineskin/request/backoff/RequestInterval.java
+++ b/core/src/main/java/org/mineskin/request/backoff/RequestInterval.java
@@ -1,0 +1,17 @@
+package org.mineskin.request.backoff;
+
+public interface RequestInterval {
+    /**
+     * @param attempt attempt number, starting from 1
+     * @return interval in milliseconds
+     */
+    int getInterval(int attempt);
+
+    static RequestInterval constant(int intervalMillis) {
+        return attempt -> intervalMillis;
+    }
+
+    static ExponentialBackoff exponential() {
+        return new ExponentialBackoff(200, 2000, 2, 3);
+    }
+}

--- a/core/src/main/java/org/mineskin/response/AbstractMineSkinResponse.java
+++ b/core/src/main/java/org/mineskin/response/AbstractMineSkinResponse.java
@@ -3,6 +3,7 @@ package org.mineskin.response;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.mineskin.data.CodeAndMessage;
+import org.mineskin.data.MutableBreadcrumbed;
 
 import java.util.*;
 
@@ -47,6 +48,9 @@ public abstract class AbstractMineSkinResponse<T> implements MineSkinResponse<T>
 
         this.rawBody = rawBody;
         this.body = parseBody(rawBody, gson, primaryField, clazz);
+        if (this.body instanceof MutableBreadcrumbed breadcrumbed) {
+            breadcrumbed.setBreadcrumb(this.breadcrumb);
+        }
     }
 
     protected T parseBody(JsonObject rawBody, Gson gson, String primaryField, Class<T> clazz) {

--- a/core/src/main/java/org/mineskin/response/MineSkinResponse.java
+++ b/core/src/main/java/org/mineskin/response/MineSkinResponse.java
@@ -1,11 +1,12 @@
 package org.mineskin.response;
 
+import org.mineskin.data.Breadcrumbed;
 import org.mineskin.data.CodeAndMessage;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface MineSkinResponse<T> {
+public interface MineSkinResponse<T> extends Breadcrumbed {
     boolean isSuccess();
 
     int getStatus();

--- a/core/src/main/java/org/mineskin/response/UserResponse.java
+++ b/core/src/main/java/org/mineskin/response/UserResponse.java
@@ -1,0 +1,7 @@
+package org.mineskin.response;
+
+import org.mineskin.data.User;
+
+public interface UserResponse {
+    User getUser();
+}

--- a/core/src/main/java/org/mineskin/response/UserResponseImpl.java
+++ b/core/src/main/java/org/mineskin/response/UserResponseImpl.java
@@ -1,0 +1,25 @@
+package org.mineskin.response;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.mineskin.data.User;
+import org.mineskin.data.UserInfo;
+
+import java.util.Map;
+
+public class UserResponseImpl extends AbstractMineSkinResponse<UserInfo> implements UserResponse {
+
+    public UserResponseImpl(int status, Map<String, String> headers, JsonObject rawBody, Gson gson, Class<UserInfo> clazz) {
+        super(status, headers, rawBody, gson, "skin", clazz);
+    }
+
+    @Override
+    protected UserInfo parseBody(JsonObject rawBody, Gson gson, String primaryField, Class<UserInfo> clazz) {
+        return gson.fromJson(rawBody, clazz);
+    }
+
+    @Override
+    public User getUser() {
+        return getBody();
+    }
+}

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-java11</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.2.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.7-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-java11</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.7-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/java11/pom.xml
+++ b/java11/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-java11</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.0.7-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/jsoup/pom.xml
+++ b/jsoup/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.7-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-jsoup</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.7-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/jsoup/pom.xml
+++ b/jsoup/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-jsoup</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.0.7-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/jsoup/pom.xml
+++ b/jsoup/pom.xml
@@ -6,17 +6,17 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-jsoup</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.mineskin</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.mineskin</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.0.7-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.mineskin</groupId>
     <artifactId>java-client-parent</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modules>
         <module>core</module>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,32 +6,32 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.7-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-tests</artifactId>
-    <version>3.0.7-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.7-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-jsoup</artifactId>
-            <version>3.0.7-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-apache</artifactId>
-            <version>3.0.7-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-java11</artifactId>
-            <version>3.0.7-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,32 +6,32 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.0.6-SNAPSHOT</version>
+        <version>3.0.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-tests</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.0.7-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-jsoup</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-apache</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-java11</artifactId>
-            <version>3.0.6-SNAPSHOT</version>
+            <version>3.0.7-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,32 +6,32 @@
     <parent>
         <groupId>org.mineskin</groupId>
         <artifactId>java-client-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>java-client-tests</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-jsoup</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-apache</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mineskin</groupId>
             <artifactId>java-client-java11</artifactId>
-            <version>3.1.0-SNAPSHOT</version>
+            <version>3.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/tests/src/main/java/org/mineskin/Example.java
+++ b/tests/src/main/java/org/mineskin/Example.java
@@ -19,8 +19,12 @@ public class Example {
             .userAgent("MyMineSkinApp/v1.0") // TODO: update this with your own user agent
             .apiKey("your-api-key") // TODO: update this with your own API key (https://account.mineskin.org/keys)
             /*
-             Uncomment this if you're on a paid plan with higher concurrency limits
+            // Uncomment this if you're on a paid plan with higher concurrency limits
             .generateQueueOptions(new QueueOptions(Executors.newSingleThreadScheduledExecutor(), 200, 5))
+            */
+            /*
+            // Use this to automatically adjust the queue settings based on your allowance
+            .generateQueueOptions(QueueOptions.createAutoGenerate())
              */
             .build();
 

--- a/tests/src/main/java/org/mineskin/Example.java
+++ b/tests/src/main/java/org/mineskin/Example.java
@@ -20,7 +20,7 @@ public class Example {
             .apiKey("your-api-key") // TODO: update this with your own API key (https://account.mineskin.org/keys)
             /*
              Uncomment this if you're on a paid plan with higher concurrency limits
-            .generateQueueOptions(new QueueOptions(Executors.newSingleThreadScheduledExecutor(), 200, 5concurrency))
+            .generateQueueOptions(new QueueOptions(Executors.newSingleThreadScheduledExecutor(), 200, 5))
              */
             .build();
 

--- a/tests/src/main/java/org/mineskin/Example.java
+++ b/tests/src/main/java/org/mineskin/Example.java
@@ -18,6 +18,10 @@ public class Example {
             .requestHandler(JsoupRequestHandler::new)
             .userAgent("MyMineSkinApp/v1.0") // TODO: update this with your own user agent
             .apiKey("your-api-key") // TODO: update this with your own API key (https://account.mineskin.org/keys)
+            /*
+             Uncomment this if you're on a paid plan with higher concurrency limits
+            .generateQueueOptions(new QueueOptions(Executors.newSingleThreadScheduledExecutor(), 200, 5concurrency))
+             */
             .build();
 
     public static void main(String[] args) {

--- a/tests/src/test/java/test/BenchmarkTest.java
+++ b/tests/src/test/java/test/BenchmarkTest.java
@@ -1,5 +1,6 @@
 package test;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mineskin.*;
 import org.mineskin.data.Visibility;
@@ -19,6 +20,7 @@ import java.util.logging.Level;
 
 import static org.junit.Assert.assertEquals;
 
+@Ignore
 public class BenchmarkTest {
 
     static {

--- a/tests/src/test/java/test/BenchmarkTest.java
+++ b/tests/src/test/java/test/BenchmarkTest.java
@@ -1,0 +1,162 @@
+package test;
+
+import org.junit.Test;
+import org.mineskin.*;
+import org.mineskin.data.Visibility;
+import org.mineskin.exception.MineSkinRequestException;
+import org.mineskin.request.GenerateRequest;
+import org.mineskin.response.QueueResponse;
+
+import java.awt.image.BufferedImage;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertEquals;
+
+public class BenchmarkTest {
+
+    static {
+        // set logger to log milliseconds
+        System.setProperty("java.util.logging.SimpleFormatter.format", "%1$tF %1$tT.%1$tL %4$s %2$s: %5$s%6$s%n");
+
+        MineSkinClientImpl.LOGGER.setLevel(Level.ALL);
+        ConsoleHandler handler = new ConsoleHandler();
+        handler.setLevel(Level.ALL);
+        MineSkinClientImpl.LOGGER.addHandler(handler);
+    }
+
+    private static int GENERATE_INTERVAL_MS = 100;
+    private static int GENERATE_CONCURRENCY = 20;
+
+    private static int GENERATE_AMOUNT = 50;
+
+    private static final Executor EXECUTOR = Executors.newSingleThreadExecutor();
+
+    private static final MineSkinClient JAVA11 = MineSkinClient.builder()
+            .requestHandler(Java11RequestHandler::new)
+            .userAgent("MineSkinClient/Benchmark")
+            .apiKey(System.getenv("MINESKIN_API_KEY"))
+            .generateExecutor(EXECUTOR)
+            .generateQueueOptions(new QueueOptions(
+                    Executors.newSingleThreadScheduledExecutor(),
+                    GENERATE_INTERVAL_MS, GENERATE_CONCURRENCY
+            ))
+            .build();
+
+    private final AtomicInteger per10s = new AtomicInteger();
+    private final AtomicInteger perMinute = new AtomicInteger();
+    private final AtomicInteger total = new AtomicInteger();
+    private long lastLog10s = System.currentTimeMillis();
+    private long lastLog = System.currentTimeMillis();
+
+    @Test
+    public void benchmark() throws InterruptedException {
+
+        log("Starting benchmark with " + GENERATE_AMOUNT + " skins, interval " + GENERATE_INTERVAL_MS + "ms, concurrency " + GENERATE_CONCURRENCY);
+
+        MineSkinClient client = JAVA11;
+        int count = GENERATE_AMOUNT;
+        Thread.sleep(1000);
+
+        CompletableFuture.runAsync(() -> {
+            while (total.get() < count) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                long now = System.currentTimeMillis();
+                if (now - lastLog10s >= 10000) {
+                    int per10s = this.per10s.get();
+                    log("Last 10s: " + per10s + " (" + (per10s / 10.0) + "/s)");
+                    this.per10s.set(0);
+                    lastLog10s = now;
+                }
+                if (now - lastLog >= 60000) {
+                    int perMinute = this.perMinute.get();
+                    log("Last minute: " + perMinute + " (" + (perMinute / 60.0) + "/s)");
+                    this.perMinute.set(0);
+                    lastLog = now;
+                }
+            }
+        });
+
+        long start = System.currentTimeMillis();
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            int finalI = i;
+            futures.add(CompletableFuture.runAsync(() -> {
+                try {
+                    generateSkin(client, finalI);
+                } catch (InterruptedException e) {
+                    System.out.println(e);
+                }
+            }));
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        log("Generated " + count + " in " + (System.currentTimeMillis() - start) + "ms");
+
+        assertEquals(count, total.get());
+
+        Thread.sleep(1000);
+    }
+
+    private void generateSkin(MineSkinClient client, int index) throws InterruptedException {
+        long jobStart = System.currentTimeMillis();
+        try {
+            Thread.sleep(10);
+            String name = "mskjva-bnch-" + index + "-" + ThreadLocalRandom.current().nextInt(1000);
+            BufferedImage image = ImageUtil.randomImage(64, ThreadLocalRandom.current().nextBoolean() ? 64 : 32);
+            GenerateRequest request = GenerateRequest.upload(image)
+                    .visibility(Visibility.UNLISTED)
+                    .name(name);
+            QueueResponse res = client.queue().submit(request).join();
+            log("[" + index + "] " + res.getBreadcrumb() + " Queue submit took " + (System.currentTimeMillis() - jobStart) + "ms - " + res.getRateLimit().next());
+            log(res);
+
+            client.queue()
+                    .waitForCompletion(res.getJob())
+                    .thenCompose(jobReference -> {
+                        log("[" + index + "] " + res.getBreadcrumb() + " Job took " + (System.currentTimeMillis() - jobStart) + "ms");
+                        return jobReference.getOrLoadSkin(client);
+                    })
+                    .thenAccept(skinInfo -> {
+                        log("[" + index + "] " + res.getBreadcrumb() + " Got skin after " + (System.currentTimeMillis() - jobStart) + "ms");
+                        log(skinInfo);
+                        per10s.incrementAndGet();
+                        perMinute.incrementAndGet();
+                        total.incrementAndGet();
+                    })
+                    .exceptionally(throwable -> {
+                        if (throwable instanceof CompletionException e && e.getCause() instanceof MineSkinRequestException req) {
+                            log(req.getResponse());
+                        } else {
+                            log(throwable);
+                        }
+                        return null;
+                    })
+                    .join();
+        } catch (CompletionException | InterruptedException e) {
+            if (e.getCause() instanceof MineSkinRequestException req) {
+                log(req.getResponse());
+            }
+            throw e;
+        }
+    }
+
+    static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("HH:mm:ss.SSS");
+
+    void log(Object message) {
+        Date date = new Date();
+        System.out.println(String.format("[%s] %s", DATE_FORMAT.format(date), message));
+    }
+
+}

--- a/tests/src/test/java/test/GenerateTest.java
+++ b/tests/src/test/java/test/GenerateTest.java
@@ -1,6 +1,7 @@
 package test;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -158,7 +159,7 @@ public class GenerateTest {
         Thread.sleep(1000);
     }
 
-
+    @Ignore
     @Test
     public void multiQueueRenderedUploadTest() throws InterruptedException, IOException {
         MineSkinClient client = JAVA11;

--- a/tests/src/test/java/test/GenerateTest.java
+++ b/tests/src/test/java/test/GenerateTest.java
@@ -167,6 +167,7 @@ public class GenerateTest {
         long start = System.currentTimeMillis();
         Map<String, JobInfo> jobs = new HashMap<>();
         for (int i = 0; i < count; i++) {
+            long jobStart = System.currentTimeMillis();
             try {
                 Thread.sleep(100);
                 String name = "mskjva-upl-" + i + "-" + ThreadLocalRandom.current().nextInt(1000);
@@ -175,7 +176,7 @@ public class GenerateTest {
                         .visibility(Visibility.UNLISTED)
                         .name(name);
                 QueueResponse res = client.queue().submit(request).join();
-                log("Queue submit took " + (System.currentTimeMillis() - start) + "ms");
+                log("Queue submit took " + (System.currentTimeMillis() - jobStart) + "ms");
                 log(res);
                 jobs.put(name, res.getBody());
             } catch (CompletionException e) {

--- a/tests/src/test/java/test/MiscTest.java
+++ b/tests/src/test/java/test/MiscTest.java
@@ -1,0 +1,44 @@
+package test;
+
+import org.junit.jupiter.api.Test;
+import org.mineskin.Java11RequestHandler;
+import org.mineskin.MineSkinClient;
+import org.mineskin.MineSkinClientImpl;
+import org.mineskin.data.User;
+import org.mineskin.response.UserResponse;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class MiscTest {
+
+    static {
+        MineSkinClientImpl.LOGGER.setLevel(Level.ALL);
+        ConsoleHandler handler = new ConsoleHandler();
+        handler.setLevel(Level.ALL);
+        MineSkinClientImpl.LOGGER.addHandler(handler);
+    }
+
+    private static final MineSkinClient JAVA11 = MineSkinClient.builder()
+            .requestHandler(Java11RequestHandler::new)
+            .userAgent("MineSkinClient-Java11/Tests")
+            .apiKey(System.getenv("MINESKIN_API_KEY"))
+            .build();
+
+    @Test
+    public void getUserTest() {
+        MineSkinClient client = JAVA11;
+        UserResponse userResponse = client.misc().getUser().join();
+        System.out.println(userResponse);
+        User user = userResponse.getUser();
+        System.out.println(user);
+        int concurrency = user.grants().concurrency().orElseThrow();
+        assertTrue(concurrency > 5);
+        int perMinute = user.grants().perMinute().orElseThrow();
+        assertTrue(perMinute > 50);
+    }
+
+}


### PR DESCRIPTION
- added support for automatically setting queue request speeds from the limits returned by the API:
```java 
 builder.generateQueueOptions(QueueOptions.createAutoGenerate())
``` 
  - added a new sub-client to request those limits: 
```java
mineskinClient.misc().getUser()
```
- improved options for job status checking:
  - added an option to use the job's ETA to schedule the first status check
  - added support for exponential backoff (or custom handlers) for the request interval
```java
builder.jobCheckOptions(
  JobCheckOptions.create()
    .withUseEta()
    .withInterval(RequestInterval.exponential())
    .withMaxAttempts(50)
)
``` 
- refactored option constructors to builder style
- added some extra debug logging and added MineSkinClient#getLogger - to enable debug logging:
```java
client.getLogger().setLevel(Level.ALL);
ConsoleHandler handler = new ConsoleHandler();
handler.setLevel(Level.ALL);
client.getLogger().addHandler(handler);
```