### PR TITLE
Add batch job check

### DIFF
--- a/core/src/main/java/org/mineskin/JobBatchChecker.java
+++ b/core/src/main/java/org/mineskin/JobBatchChecker.java
@@ -1,0 +1,230 @@
+package org.mineskin;
+
+import org.mineskin.data.JobInfo;
+import org.mineskin.data.JobReference;
+import org.mineskin.data.JobStatus;
+import org.mineskin.data.NullJobReference;
+import org.mineskin.exception.MineskinException;
+import org.mineskin.options.IJobCheckOptions;
+import org.mineskin.response.JobListResponse;
+import org.mineskin.response.JobResponse;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+
+/**
+ * Shared job checker that batches status lookups across multiple concurrent
+ * {@link MineSkinClient#queue()} waitForCompletion calls.
+ *
+ * <p>When more than {@link #BATCH_THRESHOLD} jobs are pending, polls the list
+ * endpoint once per tick instead of hitting the per-job endpoint for each.
+ * Only fetches the full per-job response (which includes the skin object) for
+ * jobs that have transitioned to {@link JobStatus#COMPLETED}.</p>
+ */
+public class JobBatchChecker {
+
+    /** Switch to list-based polling when more than this many jobs are pending. */
+    public static final int BATCH_THRESHOLD = 4;
+
+    private final MineSkinClient client;
+    private final IJobCheckOptions options;
+
+    private final Map<String, Pending> pending = new ConcurrentHashMap<>();
+    private ScheduledFuture<?> scheduledCheck;
+
+    public JobBatchChecker(MineSkinClient client, IJobCheckOptions options) {
+        this.client = client;
+        this.options = options;
+    }
+
+    /**
+     * Register a job to be polled until done. If the same job id is already
+     * registered, returns the existing future.
+     */
+    public CompletableFuture<JobReference> register(JobInfo jobInfo) {
+        long firstDelayMillis;
+        if (options.useEta() && jobInfo.eta() > 1) {
+            long etaDelay = jobInfo.eta() - System.currentTimeMillis();
+            firstDelayMillis = etaDelay > 0 ? etaDelay : options.initialDelayMillis();
+        } else {
+            firstDelayMillis = options.initialDelayMillis();
+        }
+        long nextCheckAt = System.currentTimeMillis() + firstDelayMillis;
+
+        Pending p = new Pending(jobInfo, nextCheckAt);
+        Pending prev = pending.putIfAbsent(jobInfo.id(), p);
+        if (prev != null) {
+            return prev.future;
+        }
+        client.getLogger().log(Level.FINER, "Registered job {0} for batch checking (first check in {1}ms)",
+                new Object[]{jobInfo.id(), firstDelayMillis});
+        rescheduleIfNeeded();
+        return p.future;
+    }
+
+    private synchronized void rescheduleIfNeeded() {
+        if (scheduledCheck != null) {
+            scheduledCheck.cancel(false);
+            scheduledCheck = null;
+        }
+        if (pending.isEmpty()) return;
+
+        long soonest = Long.MAX_VALUE;
+        for (Pending p : pending.values()) {
+            if (p.nextCheckAt < soonest) soonest = p.nextCheckAt;
+        }
+        long delay = Math.max(0, soonest - System.currentTimeMillis());
+        scheduledCheck = options.scheduler().schedule(this::tick, delay, TimeUnit.MILLISECONDS);
+    }
+
+    private void tick() {
+        long now = System.currentTimeMillis();
+        List<Pending> due = new ArrayList<>();
+        for (Pending p : pending.values()) {
+            if (p.nextCheckAt > now) continue;
+            int attempt = p.attempts.incrementAndGet();
+            if (attempt > options.maxAttempts()) {
+                p.future.completeExceptionally(new MineskinException("Max attempts reached")
+                        .withBreadcrumb(p.jobInfo.getBreadcrumb()));
+                pending.remove(p.jobInfo.id());
+                continue;
+            }
+            due.add(p);
+        }
+
+        if (due.isEmpty()) {
+            rescheduleIfNeeded();
+            return;
+        }
+
+        if (pending.size() > BATCH_THRESHOLD) {
+            checkViaList(due);
+        } else {
+            checkIndividually(due);
+        }
+    }
+
+    private void checkViaList(List<Pending> due) {
+        client.getLogger().log(Level.FINER, "Batch-checking {0} pending jobs via list endpoint",
+                pending.size());
+        client.queue().list().whenComplete((response, throwable) -> {
+            try {
+                if (throwable != null) {
+                    // Match existing JobChecker semantics: request exceptions fail the waiting jobs.
+                    for (Pending p : due) {
+                        p.future.completeExceptionally(throwable);
+                        pending.remove(p.jobInfo.id());
+                    }
+                    return;
+                }
+                Map<String, JobInfo> byId = indexById(response);
+                long now = System.currentTimeMillis();
+                // Process ALL pending jobs — the list response gives us everything for free.
+                for (Pending p : new ArrayList<>(pending.values())) {
+                    JobInfo updated = byId.get(p.jobInfo.id());
+                    if (updated != null) {
+                        p.jobInfo = updated;
+                    } else if (!due.contains(p)) {
+                        // Not due and not in list response — leave as-is for its own tick.
+                        continue;
+                    }
+                    handleStatus(p, now);
+                }
+            } finally {
+                rescheduleIfNeeded();
+            }
+        });
+    }
+
+    private void checkIndividually(List<Pending> due) {
+        AtomicInteger remaining = new AtomicInteger(due.size());
+        for (Pending p : due) {
+            client.queue().get(p.jobInfo).whenComplete((response, throwable) -> {
+                try {
+                    if (throwable != null) {
+                        p.future.completeExceptionally(throwable);
+                        pending.remove(p.jobInfo.id());
+                        return;
+                    }
+                    JobInfo info = response.getBody();
+                    if (info != null) {
+                        p.jobInfo = info;
+                    }
+                    JobStatus status = p.jobInfo.status();
+                    if (status == JobStatus.FAILED ||
+                            (status == JobStatus.COMPLETED && p.jobInfo.result().isPresent())) {
+                        p.future.complete(response);
+                        pending.remove(p.jobInfo.id());
+                    } else {
+                        p.nextCheckAt = System.currentTimeMillis()
+                                + options.interval().getInterval(p.attempts.get());
+                    }
+                } finally {
+                    if (remaining.decrementAndGet() == 0) {
+                        rescheduleIfNeeded();
+                    }
+                }
+            });
+        }
+    }
+
+    private void handleStatus(Pending p, long now) {
+        JobStatus status = p.jobInfo.status();
+        if (status == JobStatus.FAILED) {
+            // List endpoint doesn't return error details, and the result field is empty
+            // for failures — return a NullJobReference so callers still get the updated JobInfo.
+            p.future.complete(new NullJobReference(p.jobInfo));
+            pending.remove(p.jobInfo.id());
+            return;
+        }
+        if (status == JobStatus.COMPLETED && p.jobInfo.result().isPresent()) {
+            // List only has the skin uuid in `result`; fetch the full response for the skin object.
+            pending.remove(p.jobInfo.id());
+            fetchFullAndComplete(p);
+            return;
+        }
+        // Still pending — back off based on the current attempt number.
+        p.nextCheckAt = now + options.interval().getInterval(p.attempts.get());
+    }
+
+    private void fetchFullAndComplete(Pending p) {
+        client.queue().get(p.jobInfo).whenComplete((JobResponse response, Throwable throwable) -> {
+            if (throwable != null) {
+                p.future.completeExceptionally(throwable);
+            } else {
+                p.future.complete(response);
+            }
+        });
+    }
+
+    private static Map<String, JobInfo> indexById(JobListResponse response) {
+        List<JobInfo> jobs = response.getJobs();
+        if (jobs == null || jobs.isEmpty()) return Map.of();
+        Map<String, JobInfo> byId = new HashMap<>(jobs.size());
+        for (JobInfo j : jobs) {
+            if (j.id() != null) byId.put(j.id(), j);
+        }
+        return byId;
+    }
+
+    private static final class Pending {
+        volatile JobInfo jobInfo;
+        final CompletableFuture<JobReference> future = new CompletableFuture<>();
+        final AtomicInteger attempts = new AtomicInteger(0);
+        volatile long nextCheckAt;
+
+        Pending(JobInfo jobInfo, long nextCheckAt) {
+            this.jobInfo = jobInfo;
+            this.nextCheckAt = nextCheckAt;
+        }
+    }
+
+}

--- a/core/src/main/java/org/mineskin/MineSkinClientImpl.java
+++ b/core/src/main/java/org/mineskin/MineSkinClientImpl.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonObject;
 import org.mineskin.data.*;
 import org.mineskin.exception.MineSkinRequestException;
 import org.mineskin.exception.MineskinException;
-import org.mineskin.options.IJobCheckOptions;
 import org.mineskin.request.*;
 import org.mineskin.request.source.UploadSource;
 import org.mineskin.response.*;
@@ -73,6 +72,22 @@ public class MineSkinClientImpl implements MineSkinClient {
     }
 
     class QueueClientImpl implements QueueClient {
+
+        private volatile JobBatchChecker jobBatchChecker;
+
+        private JobBatchChecker batchChecker() {
+            JobBatchChecker local = jobBatchChecker;
+            if (local == null) {
+                synchronized (this) {
+                    local = jobBatchChecker;
+                    if (local == null) {
+                        local = new JobBatchChecker(MineSkinClientImpl.this, executors.jobCheckOptions());
+                        jobBatchChecker = local;
+                    }
+                }
+            }
+            return local;
+        }
 
         @Override
         public CompletableFuture<QueueResponse> submit(GenerateRequest request) {
@@ -196,8 +211,7 @@ public class MineSkinClientImpl implements MineSkinClient {
             if (jobInfo.id() == null) {
                 return CompletableFuture.completedFuture(new NullJobReference(jobInfo));
             }
-            IJobCheckOptions options = executors.jobCheckOptions();
-            return new JobChecker(MineSkinClientImpl.this, jobInfo, options).check();
+            return batchChecker().register(jobInfo);
         }
 
 

--- a/tests/src/test/java/test/JobBatchCheckerTest.java
+++ b/tests/src/test/java/test/JobBatchCheckerTest.java
@@ -1,0 +1,250 @@
+package test;
+
+import org.junit.jupiter.api.Test;
+import org.mineskin.JobBatchChecker;
+import org.mineskin.JobCheckOptions;
+import org.mineskin.MineSkinClient;
+import org.mineskin.GenerateClient;
+import org.mineskin.MiscClient;
+import org.mineskin.QueueClient;
+import org.mineskin.SkinsClient;
+import org.mineskin.data.CodeAndMessage;
+import org.mineskin.data.JobInfo;
+import org.mineskin.data.JobReference;
+import org.mineskin.data.JobStatus;
+import org.mineskin.data.SkinInfo;
+import org.mineskin.request.GenerateRequest;
+import org.mineskin.request.backoff.RequestInterval;
+import org.mineskin.response.JobListResponse;
+import org.mineskin.response.JobResponse;
+import org.mineskin.response.MineSkinResponse;
+import org.mineskin.response.QueueResponse;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JobBatchCheckerTest {
+
+    private static final Logger LOGGER = Logger.getLogger("JobBatchCheckerTest");
+
+    @Test
+    public void batchesViaListWhenManyPending() throws Exception {
+        FakeQueueClient queue = new FakeQueueClient();
+        MineSkinClient client = new FakeMineSkinClient(queue);
+        for (int i = 0; i < 5; i++) {
+            queue.setStatus("job" + i, JobStatus.WAITING, null);
+        }
+
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            JobCheckOptions options = JobCheckOptions.create(scheduler)
+                    .withInitialDelay(30)
+                    .withInterval(RequestInterval.constant(40))
+                    .withMaxAttempts(50);
+            JobBatchChecker checker = new JobBatchChecker(client, options);
+
+            List<CompletableFuture<JobReference>> futures = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                JobInfo job = new JobInfo("job" + i, JobStatus.WAITING, System.currentTimeMillis(), null);
+                futures.add(checker.register(job));
+            }
+
+            // Let at least one tick run against all-pending state.
+            Thread.sleep(150);
+            int listCallsBeforeCompletion = queue.listCalls.get();
+            assertTrue(listCallsBeforeCompletion >= 1,
+                    "list() should be used when >4 jobs pending, calls=" + listCallsBeforeCompletion);
+            assertTrue(queue.getCallsForId.isEmpty(),
+                    "get() should not be called while jobs are still pending, calls=" + queue.getCallsForId);
+
+            // Mark jobs done: 3 completed, 1 failed, 1 still waiting.
+            queue.setStatus("job0", JobStatus.COMPLETED, "uuid-0");
+            queue.setStatus("job1", JobStatus.COMPLETED, "uuid-1");
+            queue.setStatus("job2", JobStatus.COMPLETED, "uuid-2");
+            queue.setStatus("job3", JobStatus.FAILED, null);
+
+            // Wait for the four finished futures to resolve.
+            for (int i = 0; i < 4; i++) {
+                JobReference ref = awaitFuture(futures.get(i), 2000);
+                assertEquals("job" + i, ref.getJob().id());
+            }
+            assertFalse(futures.get(4).isDone(), "still-waiting job should not have completed");
+
+            // Each COMPLETED job should trigger exactly one per-job get() (for skin). FAILED should not.
+            assertEquals(1, queue.getCallsForId.getOrDefault("job0", 0).intValue());
+            assertEquals(1, queue.getCallsForId.getOrDefault("job1", 0).intValue());
+            assertEquals(1, queue.getCallsForId.getOrDefault("job2", 0).intValue());
+            assertEquals(0, queue.getCallsForId.getOrDefault("job3", 0).intValue(),
+                    "FAILED jobs should be resolved from list response without a per-job get()");
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    @Test
+    public void usesIndividualGetsWhenFewPending() throws Exception {
+        FakeQueueClient queue = new FakeQueueClient();
+        MineSkinClient client = new FakeMineSkinClient(queue);
+        for (int i = 0; i < 3; i++) {
+            queue.setStatus("job" + i, JobStatus.WAITING, null);
+        }
+
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            JobCheckOptions options = JobCheckOptions.create(scheduler)
+                    .withInitialDelay(30)
+                    .withInterval(RequestInterval.constant(40))
+                    .withMaxAttempts(50);
+            JobBatchChecker checker = new JobBatchChecker(client, options);
+
+            List<CompletableFuture<JobReference>> futures = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                JobInfo job = new JobInfo("job" + i, JobStatus.WAITING, System.currentTimeMillis(), null);
+                futures.add(checker.register(job));
+            }
+
+            Thread.sleep(150);
+            assertEquals(0, queue.listCalls.get(),
+                    "list() should not be used when pending <= threshold");
+            assertTrue(queue.getCallsForId.size() > 0,
+                    "get() should have been called for each pending job");
+
+            queue.setStatus("job0", JobStatus.COMPLETED, "uuid-0");
+            queue.setStatus("job1", JobStatus.COMPLETED, "uuid-1");
+            queue.setStatus("job2", JobStatus.COMPLETED, "uuid-2");
+
+            for (int i = 0; i < 3; i++) {
+                JobReference ref = awaitFuture(futures.get(i), 2000);
+                assertEquals("job" + i, ref.getJob().id());
+            }
+            assertEquals(0, queue.listCalls.get(), "list() must not be used in small-batch mode");
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+
+    private static JobReference awaitFuture(CompletableFuture<JobReference> future, long timeoutMs)
+            throws InterruptedException, TimeoutException, ExecutionException {
+        try {
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            fail("Timed out after " + timeoutMs + "ms waiting for job");
+            throw e;
+        }
+    }
+
+    // ---------- fakes ----------
+
+    private static final class FakeMineSkinClient implements MineSkinClient {
+        private final QueueClient queue;
+
+        FakeMineSkinClient(QueueClient queue) {
+            this.queue = queue;
+        }
+
+        @Override public QueueClient queue() { return queue; }
+        @Override public GenerateClient generate() { return null; }
+        @Override public SkinsClient skins() { return null; }
+        @Override public MiscClient misc() { return null; }
+        @Override public Logger getLogger() { return LOGGER; }
+    }
+
+    private static final class FakeQueueClient implements QueueClient {
+        final AtomicInteger listCalls = new AtomicInteger();
+        final Map<String, Integer> getCallsForId = new ConcurrentHashMap<>();
+        private final Map<String, JobInfo> state = new ConcurrentHashMap<>();
+
+        void setStatus(String id, JobStatus status, String result) {
+            state.put(id, new JobInfo(id, status, System.currentTimeMillis(), result));
+        }
+
+        @Override
+        public CompletableFuture<QueueResponse> submit(GenerateRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CompletableFuture<JobResponse> get(JobInfo jobInfo) {
+            return get(jobInfo.id());
+        }
+
+        @Override
+        public CompletableFuture<JobResponse> get(String id) {
+            getCallsForId.merge(id, 1, Integer::sum);
+            JobInfo current = state.getOrDefault(id, new JobInfo(id, JobStatus.UNKNOWN, System.currentTimeMillis(), null));
+            SkinInfo skin = null; // tests don't need the real skin object
+            return CompletableFuture.completedFuture(new FakeJobResponse(current, skin));
+        }
+
+        @Override
+        public CompletableFuture<JobListResponse> list() {
+            listCalls.incrementAndGet();
+            List<JobInfo> snapshot = new ArrayList<>(state.values());
+            return CompletableFuture.completedFuture(new FakeJobListResponse(snapshot));
+        }
+
+        @Override
+        public CompletableFuture<JobReference> waitForCompletion(JobInfo jobInfo) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static abstract class FakeResponse<T> implements MineSkinResponse<T> {
+        @Override public boolean isSuccess() { return true; }
+        @Override public int getStatus() { return 200; }
+        @Override public List<CodeAndMessage> getMessages() { return Collections.emptyList(); }
+        @Override public Optional<CodeAndMessage> getFirstMessage() { return Optional.empty(); }
+        @Override public List<CodeAndMessage> getErrors() { return Collections.emptyList(); }
+        @Override public boolean hasErrors() { return false; }
+        @Override public Optional<CodeAndMessage> getFirstError() { return Optional.empty(); }
+        @Override public Optional<CodeAndMessage> getErrorOrMessage() { return Optional.empty(); }
+        @Override public List<CodeAndMessage> getWarnings() { return Collections.emptyList(); }
+        @Override public Optional<CodeAndMessage> getFirstWarning() { return Optional.empty(); }
+        @Override public String getServer() { return "test"; }
+        @Override public String getBreadcrumb() { return null; }
+    }
+
+    private static final class FakeJobResponse extends FakeResponse<JobInfo> implements JobResponse {
+        private final JobInfo job;
+        private final SkinInfo skin;
+
+        FakeJobResponse(JobInfo job, SkinInfo skin) {
+            this.job = job;
+            this.skin = skin;
+        }
+
+        @Override public JobInfo getBody() { return job; }
+        @Override public JobInfo getJob() { return job; }
+        @Override public Optional<SkinInfo> getSkin() { return Optional.ofNullable(skin); }
+        @Override public CompletableFuture<SkinInfo> getOrLoadSkin(MineSkinClient client) {
+            return CompletableFuture.completedFuture(skin);
+        }
+    }
+
+    private static final class FakeJobListResponse extends FakeResponse<List<JobInfo>> implements JobListResponse {
+        private final List<JobInfo> jobs;
+
+        FakeJobListResponse(List<JobInfo> jobs) {
+            this.jobs = jobs;
+        }
+
+        @Override public List<JobInfo> getBody() { return jobs; }
+        @Override public List<JobInfo> getJobs() { return jobs; }
+    }
+
+}


### PR DESCRIPTION
Share a single JobBatchChecker across all waitForCompletion() calls.
When more than 4 jobs are pending, poll /v2/queue once per tick instead
of hitting /v2/queue/{id} for each. Per-job GET is only made for
COMPLETED jobs (needed for the skin object); FAILED jobs resolve via
NullJobReference from the list response.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>