### PR TITLE
distinguish failed jobs from not-yet-completed 

### DIFF
--- a/core/src/main/java/org/mineskin/JobBatchChecker.java
+++ b/core/src/main/java/org/mineskin/JobBatchChecker.java
@@ -3,7 +3,7 @@ package org.mineskin;
 import org.mineskin.data.JobInfo;
 import org.mineskin.data.JobReference;
 import org.mineskin.data.JobStatus;
-import org.mineskin.data.NullJobReference;
+import org.mineskin.data.ListJobReferenceImpl;
 import org.mineskin.exception.MineskinException;
 import org.mineskin.options.IJobCheckOptions;
 import org.mineskin.response.JobListResponse;
@@ -185,8 +185,8 @@ public class JobBatchChecker {
         JobStatus status = p.jobInfo.status();
         if (status == JobStatus.FAILED) {
             // List endpoint doesn't return error details, and the result field is empty
-            // for failures — return a NullJobReference so callers still get the updated JobInfo.
-            p.future.complete(new NullJobReference(p.jobInfo));
+            // for failures — return a ListJobReferenceImpl so callers still get the updated JobInfo.
+            p.future.complete(new ListJobReferenceImpl(p.jobInfo));
             pending.remove(p.jobInfo.id());
             return;
         }

--- a/core/src/main/java/org/mineskin/data/JobInfo.java
+++ b/core/src/main/java/org/mineskin/data/JobInfo.java
@@ -66,6 +66,9 @@ public class JobInfo implements MutableBreadcrumbed {
     }
 
     public CompletableFuture<SkinResponse> getSkin(MineSkinClient client) {
+        if (status() == JobStatus.FAILED) {
+            throw new MineskinException("Job failed").withBreadcrumb(getBreadcrumb());
+        }
         if (result == null) {
             throw new MineskinException("Job is not completed yet").withBreadcrumb(getBreadcrumb());
         }

--- a/core/src/main/java/org/mineskin/data/JobReference.java
+++ b/core/src/main/java/org/mineskin/data/JobReference.java
@@ -1,6 +1,7 @@
 package org.mineskin.data;
 
 import org.mineskin.MineSkinClient;
+import org.mineskin.exception.MineskinException;
 import org.mineskin.response.SkinResponse;
 
 import java.util.Optional;
@@ -12,10 +13,12 @@ public interface JobReference {
     Optional<SkinInfo> getSkin();
 
     default CompletableFuture<SkinInfo> getOrLoadSkin(MineSkinClient client) {
+        if (getJob().status() == JobStatus.FAILED) {
+            throw new MineskinException("Job failed").withBreadcrumb(getJob().getBreadcrumb());
+        }
         if (this.getSkin().isPresent()) {
             return CompletableFuture.completedFuture(this.getSkin().get());
-        } else {
-            return getJob().getSkin(client).thenApply(SkinResponse::getSkin);
         }
+        return getJob().getSkin(client).thenApply(SkinResponse::getSkin);
     }
 }

--- a/core/src/main/java/org/mineskin/data/ListJobReferenceImpl.java
+++ b/core/src/main/java/org/mineskin/data/ListJobReferenceImpl.java
@@ -1,0 +1,22 @@
+package org.mineskin.data;
+
+import java.util.Optional;
+
+public class ListJobReferenceImpl implements JobReference {
+
+    private final JobInfo job;
+
+    public ListJobReferenceImpl(JobInfo job) {
+        this.job = job;
+    }
+
+    @Override
+    public JobInfo getJob() {
+        return job;
+    }
+
+    @Override
+    public Optional<SkinInfo> getSkin() {
+        return Optional.empty();
+    }
+}

--- a/core/src/main/java/org/mineskin/response/JobResponseImpl.java
+++ b/core/src/main/java/org/mineskin/response/JobResponseImpl.java
@@ -4,7 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.mineskin.MineSkinClient;
 import org.mineskin.data.JobInfo;
+import org.mineskin.data.JobStatus;
 import org.mineskin.data.SkinInfo;
+import org.mineskin.exception.MineSkinRequestException;
 
 import java.util.Map;
 import java.util.Optional;
@@ -31,15 +33,17 @@ public class JobResponseImpl extends AbstractMineSkinResponse<JobInfo> implement
 
     @Override
     public CompletableFuture<SkinInfo> getOrLoadSkin(MineSkinClient client) {
+        if (getJob().status() == JobStatus.FAILED) {
+            throw new MineSkinRequestException("job_failed", "Job failed", this);
+        }
         if (this.skin != null) {
             this.skin.setBreadcrumb(getBreadcrumb());
             return CompletableFuture.completedFuture(this.skin);
-        } else {
-            return getJob().getSkin(client).thenApply(skin -> {
-                this.skin = skin.getSkin();
-                return this.skin;
-            });
         }
+        return getJob().getSkin(client).thenApply(skin -> {
+            this.skin = skin.getSkin();
+            return this.skin;
+        });
     }
 
 }


### PR DESCRIPTION
JobBatchChecker now returns a proper ListJobReferenceImpl (replacing NullJobReference) for FAILED jobs discovered via the list endpoint, so callers can read the failure status off the JobInfo.

getOrLoadSkin and JobInfo#getSkin now short-circuit on JobStatus.FAILED with a "Job failed" error, instead of falling through to the generic "Job is not completed yet" path that only made sense for pending jobs. JobResponseImpl throws MineSkinRequestException so callers get access to the underlying response; JobInfo / JobReference throw MineskinException.