### PR TITLE
auto-throttle generate queue after job failures

### DIFF
--- a/core/src/main/java/org/mineskin/JobBatchChecker.java
+++ b/core/src/main/java/org/mineskin/JobBatchChecker.java
@@ -35,13 +35,19 @@ public class JobBatchChecker {
 
     private final MineSkinClient client;
     private final IJobCheckOptions options;
+    private final Runnable onJobFailure;
 
     private final Map<String, Pending> pending = new ConcurrentHashMap<>();
     private ScheduledFuture<?> scheduledCheck;
 
     public JobBatchChecker(MineSkinClient client, IJobCheckOptions options) {
+        this(client, options, null);
+    }
+
+    public JobBatchChecker(MineSkinClient client, IJobCheckOptions options, Runnable onJobFailure) {
         this.client = client;
         this.options = options;
+        this.onJobFailure = onJobFailure;
     }
 
     /**
@@ -167,6 +173,9 @@ public class JobBatchChecker {
                             (status == JobStatus.COMPLETED && p.jobInfo.result().isPresent())) {
                         p.future.complete(response);
                         pending.remove(p.jobInfo.id());
+                        if (status == JobStatus.FAILED && onJobFailure != null) {
+                            onJobFailure.run();
+                        }
                     } else {
                         p.nextCheckAt = System.currentTimeMillis()
                                 + options.interval().getInterval(p.attempts.get());
@@ -187,6 +196,9 @@ public class JobBatchChecker {
             // List response doesn't carry error details (for FAILED) or the skin object
             // (for COMPLETED) — fetch the full per-job response so callers can read them.
             pending.remove(p.jobInfo.id());
+            if (status == JobStatus.FAILED && onJobFailure != null) {
+                onJobFailure.run();
+            }
             fetchFullAndComplete(p);
             return;
         }

--- a/core/src/main/java/org/mineskin/JobChecker.java
+++ b/core/src/main/java/org/mineskin/JobChecker.java
@@ -27,8 +27,13 @@ public class JobChecker {
     private final RequestInterval interval;
     private final TimeUnit timeUnit;
     private final boolean useEta;
+    private final Runnable onJobFailure;
 
     public JobChecker(MineSkinClient client, JobInfo jobInfo, IJobCheckOptions options) {
+        this(client, jobInfo, options, null);
+    }
+
+    public JobChecker(MineSkinClient client, JobInfo jobInfo, IJobCheckOptions options, Runnable onJobFailure) {
         this.client = client;
         this.jobInfo = jobInfo;
         this.executor = options.scheduler();
@@ -37,6 +42,7 @@ public class JobChecker {
         this.interval = options.interval();
         this.timeUnit = TimeUnit.MILLISECONDS;
         this.useEta = options.useEta();
+        this.onJobFailure = onJobFailure;
     }
 
     @Deprecated
@@ -59,6 +65,7 @@ public class JobChecker {
         this.interval = RequestInterval.constant((int) timeUnit.toMillis(interval));
         this.timeUnit = timeUnit;
         this.useEta = useEta;
+        this.onJobFailure = null;
     }
 
     /**
@@ -101,6 +108,9 @@ public class JobChecker {
                     if (jobInfo.status() == JobStatus.FAILED ||
                             (jobInfo.status() == JobStatus.COMPLETED && jobInfo.result().isPresent())) {
                         future.complete(response);
+                        if (jobInfo.status() == JobStatus.FAILED && onJobFailure != null) {
+                            onJobFailure.run();
+                        }
                     } else {
                         // Either still pending, or completed but result not yet available (server-side race) — keep polling
                         executor.schedule(this::checkJob, interval.getInterval(attempt), timeUnit);

--- a/core/src/main/java/org/mineskin/MineSkinClientImpl.java
+++ b/core/src/main/java/org/mineskin/MineSkinClientImpl.java
@@ -81,7 +81,11 @@ public class MineSkinClientImpl implements MineSkinClient {
                 synchronized (this) {
                     local = jobBatchChecker;
                     if (local == null) {
-                        local = new JobBatchChecker(MineSkinClientImpl.this, executors.jobCheckOptions());
+                        local = new JobBatchChecker(
+                                MineSkinClientImpl.this,
+                                executors.jobCheckOptions(),
+                                executors.generateQueueOptions()::reportFailure
+                        );
                         jobBatchChecker = local;
                     }
                 }

--- a/core/src/main/java/org/mineskin/options/AutoGenerateQueueOptions.java
+++ b/core/src/main/java/org/mineskin/options/AutoGenerateQueueOptions.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import java.util.logging.Level;
 
 public class AutoGenerateQueueOptions implements IQueueOptions {
@@ -20,7 +21,13 @@ public class AutoGenerateQueueOptions implements IQueueOptions {
     private static final int MIN_CONCURRENCY = 1;
     private static final int MAX_CONCURRENCY = 30;
 
+    private static final int FAILURE_STEP_MILLIS = 500;
+    private static final int MAX_PENALTY_MILLIS = 10_000;
+    private static final int DECAY_MILLIS_PER_SECOND = 100;
+    private static final int MAX_EFFECTIVE_INTERVAL_MILLIS = 10_000;
+
     private final ScheduledExecutorService scheduler;
+    private final LongSupplier clock;
     private MineSkinClient client;
 
     private final AtomicLong lastRefresh = new AtomicLong(0);
@@ -28,10 +35,18 @@ public class AutoGenerateQueueOptions implements IQueueOptions {
     private final AtomicInteger intervalMillis = new AtomicInteger(MAX_INTERVAL_MILLIS);
     private final AtomicInteger concurrency = new AtomicInteger(MIN_INTERVAL_MILLIS);
 
+    private final AtomicInteger peakPenaltyMillis = new AtomicInteger(0);
+    private final AtomicLong lastFailureAt = new AtomicLong(0);
+
     public AutoGenerateQueueOptions(
             ScheduledExecutorService scheduler
     ) {
+        this(scheduler, System::currentTimeMillis);
+    }
+
+    AutoGenerateQueueOptions(ScheduledExecutorService scheduler, LongSupplier clock) {
         this.scheduler = scheduler;
+        this.clock = clock;
     }
 
     public AutoGenerateQueueOptions() {
@@ -55,13 +70,40 @@ public class AutoGenerateQueueOptions implements IQueueOptions {
     @Override
     public int intervalMillis() {
         reloadIfNeeded();
-        return intervalMillis.get();
+        int effective = intervalMillis.get() + currentPenalty();
+        return Math.min(effective, MAX_EFFECTIVE_INTERVAL_MILLIS);
     }
 
     @Override
     public int concurrency() {
         reloadIfNeeded();
         return concurrency.get();
+    }
+
+    @Override
+    public void reportFailure() {
+        int penalty;
+        int baseline;
+        synchronized (this) {
+            int existing = currentPenalty();
+            penalty = Math.min(MAX_PENALTY_MILLIS, existing + FAILURE_STEP_MILLIS);
+            peakPenaltyMillis.set(penalty);
+            lastFailureAt.set(clock.getAsLong());
+            baseline = intervalMillis.get();
+        }
+        int effective = Math.min(baseline + penalty, MAX_EFFECTIVE_INTERVAL_MILLIS);
+        MineSkinClientImpl.LOGGER.log(Level.INFO,
+                "[QueueOptions] Slowing down after failure: penalty {0}ms, effective {1}ms (baseline {2}ms)",
+                new Object[]{penalty, effective, baseline});
+    }
+
+    private int currentPenalty() {
+        int peak = peakPenaltyMillis.get();
+        if (peak == 0) return 0;
+        long elapsed = clock.getAsLong() - lastFailureAt.get();
+        if (elapsed <= 0) return peak;
+        long decayed = peak - (elapsed * DECAY_MILLIS_PER_SECOND / 1000);
+        return (int) Math.max(0, decayed);
     }
 
     private void reloadIfNeeded() {

--- a/core/src/main/java/org/mineskin/options/IQueueOptions.java
+++ b/core/src/main/java/org/mineskin/options/IQueueOptions.java
@@ -20,10 +20,4 @@ public interface IQueueOptions {
     default void reportFailure() {
     }
 
-    /**
-     * Report that a job handled by this queue succeeded. Reserved for future use
-     * by adaptive implementations. No-op by default.
-     */
-    default void reportSuccess() {
-    }
 }

--- a/core/src/main/java/org/mineskin/options/IQueueOptions.java
+++ b/core/src/main/java/org/mineskin/options/IQueueOptions.java
@@ -11,4 +11,19 @@ public interface IQueueOptions {
     int intervalMillis();
 
     int concurrency();
+
+    /**
+     * Report that a job handled by this queue failed. Adaptive implementations
+     * (see {@link AutoGenerateQueueOptions}) use this signal to temporarily slow
+     * down the request rate. No-op by default.
+     */
+    default void reportFailure() {
+    }
+
+    /**
+     * Report that a job handled by this queue succeeded. Reserved for future use
+     * by adaptive implementations. No-op by default.
+     */
+    default void reportSuccess() {
+    }
 }

--- a/tests/src/test/java/org/mineskin/options/AutoGenerateQueueOptionsTest.java
+++ b/tests/src/test/java/org/mineskin/options/AutoGenerateQueueOptionsTest.java
@@ -1,0 +1,102 @@
+package org.mineskin.options;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AutoGenerateQueueOptionsTest {
+
+    @Test
+    public void intervalReturnsBaselineWhenNoFailures() {
+        AutoGenerateQueueOptions options = new AutoGenerateQueueOptions(
+                Executors.newSingleThreadScheduledExecutor(), () -> 0L);
+        // Baseline defaults to MAX_INTERVAL_MILLIS (1000) until grants are loaded.
+        assertEquals(1000, options.intervalMillis());
+    }
+
+    @Test
+    public void reportFailureAddsPenaltyImmediately() {
+        AtomicLong now = new AtomicLong(10_000);
+        AutoGenerateQueueOptions options = new AutoGenerateQueueOptions(
+                Executors.newSingleThreadScheduledExecutor(), now::get);
+
+        int before = options.intervalMillis();
+        options.reportFailure();
+        int after = options.intervalMillis();
+
+        assertEquals(before + 500, after, "single failure adds FAILURE_STEP_MILLIS");
+    }
+
+    @Test
+    public void penaltyDecaysLinearlyBackToBaseline() {
+        AtomicLong now = new AtomicLong(10_000);
+        AutoGenerateQueueOptions options = new AutoGenerateQueueOptions(
+                Executors.newSingleThreadScheduledExecutor(), now::get);
+        int baseline = options.intervalMillis();
+
+        options.reportFailure();
+        assertEquals(baseline + 500, options.intervalMillis());
+
+        // Decay rate is 100ms/s, so a 500ms penalty clears in 5 seconds. Halfway through: 250ms left.
+        now.addAndGet(2500);
+        assertEquals(baseline + 250, options.intervalMillis());
+
+        // Fully decayed after another 2.5s (+ a little).
+        now.addAndGet(2600);
+        assertEquals(baseline, options.intervalMillis());
+    }
+
+    @Test
+    public void repeatedFailuresStackOnDecayingPenalty() {
+        AtomicLong now = new AtomicLong(10_000);
+        AutoGenerateQueueOptions options = new AutoGenerateQueueOptions(
+                Executors.newSingleThreadScheduledExecutor(), now::get);
+        int baseline = options.intervalMillis();
+
+        options.reportFailure();
+        assertEquals(baseline + 500, options.intervalMillis());
+
+        // After 2s, penalty has decayed from 500 to 300.
+        now.addAndGet(2000);
+        assertEquals(baseline + 300, options.intervalMillis());
+
+        // New failure stacks on the current (decayed) penalty: 300 + 500 = 800.
+        options.reportFailure();
+        assertEquals(baseline + 800, options.intervalMillis());
+    }
+
+    @Test
+    public void penaltyClampsAtMax() {
+        AtomicLong now = new AtomicLong(10_000);
+        AutoGenerateQueueOptions options = new AutoGenerateQueueOptions(
+                Executors.newSingleThreadScheduledExecutor(), now::get);
+
+        // 25 failures back-to-back would naively reach 12_500ms — should cap at 10_000.
+        for (int i = 0; i < 25; i++) {
+            options.reportFailure();
+        }
+
+        int effective = options.intervalMillis();
+        // Baseline (1000) + capped penalty (10_000) would be 11_000, but effective clamps at 10_000.
+        assertTrue(effective <= 10_000, "effective interval clamped at MAX_EFFECTIVE_INTERVAL_MILLIS, got " + effective);
+        assertTrue(effective >= 10_000 - 100, "should be near the ceiling, got " + effective);
+    }
+
+    @Test
+    public void realClockConstructorStillWorks() {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            AutoGenerateQueueOptions options = new AutoGenerateQueueOptions(scheduler);
+            int baseline = options.intervalMillis();
+            options.reportFailure();
+            assertEquals(baseline + 500, options.intervalMillis());
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+}

--- a/tests/src/test/java/test/BenchmarkTest.java
+++ b/tests/src/test/java/test/BenchmarkTest.java
@@ -7,6 +7,7 @@ import org.mineskin.data.Breadcrumbed;
 import org.mineskin.data.JobStatus;
 import org.mineskin.data.Visibility;
 import org.mineskin.exception.MineSkinRequestException;
+import org.mineskin.options.GenerateQueueOptions;
 import org.mineskin.request.GenerateRequest;
 import org.mineskin.request.backoff.RequestInterval;
 import org.mineskin.response.QueueResponse;
@@ -50,11 +51,7 @@ public class BenchmarkTest {
             .userAgent("MineSkinClient/Benchmark")
             .apiKey(System.getenv("MINESKIN_API_KEY"))
             .generateExecutor(GENERATE_EXECUTOR)
-            .generateQueueOptions(new QueueOptions(
-                    Executors.newSingleThreadScheduledExecutor(),
-                    GENERATE_INTERVAL_MS, GENERATE_CONCURRENCY
-            ))
-//            .generateQueueOptions(QueueOptions.createAutoGenerate())
+            .generateQueueOptions(GenerateQueueOptions.createAuto())
             .jobCheckOptions(JobCheckOptions.create().withUseEta().withInterval(RequestInterval.exponential()).withMaxAttempts(50))
             .build();
 


### PR DESCRIPTION
AutoGenerateQueueOptions now stacks a time-decaying penalty on top of the grants-derived baseline interval. Each JobStatus.FAILED signal from JobBatchChecker bumps the penalty by 500ms (capped at 10s); it decays linearly at 100ms per second back to baseline. Repeated failures stack on the already-decaying penalty, so sustained errors push the interval higher before it settles. Logs at INFO when the throttle kicks in.

IQueueOptions gets default no-op reportFailure() / reportSuccess() methods so non-adaptive implementations are unaffected.