### PR TITLE
Add request/response interceptors to RequestHandlers 

### DIFF
--- a/apache/src/main/java/org/mineskin/ApacheRequestHandler.java
+++ b/apache/src/main/java/org/mineskin/ApacheRequestHandler.java
@@ -10,6 +10,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
@@ -19,6 +20,9 @@ import org.mineskin.data.CodeAndMessage;
 import org.mineskin.exception.MineSkinRequestException;
 import org.mineskin.exception.MineskinException;
 import org.mineskin.request.RequestHandler;
+import org.mineskin.request.RequestHandlerConstructor;
+import org.mineskin.request.RequestInterceptor;
+import org.mineskin.request.ResponseInterceptor;
 import org.mineskin.response.MineSkinResponse;
 import org.mineskin.response.ResponseConstructor;
 
@@ -38,14 +42,28 @@ public class ApacheRequestHandler extends RequestHandler {
     private final Gson gson;
 
     private final HttpClient httpClient;
+    private final List<RequestInterceptor<HttpUriRequest>> requestInterceptors;
+    private final List<ResponseInterceptor<HttpResponse>> responseInterceptors;
 
     public ApacheRequestHandler(
             String baseUrl,
             String userAgent, String apiKey,
             int timeout,
             Gson gson) {
+        this(baseUrl, userAgent, apiKey, timeout, gson, List.of(), List.of());
+    }
+
+    private ApacheRequestHandler(
+            String baseUrl,
+            String userAgent, String apiKey,
+            int timeout,
+            Gson gson,
+            List<RequestInterceptor<HttpUriRequest>> requestInterceptors,
+            List<ResponseInterceptor<HttpResponse>> responseInterceptors) {
         super(baseUrl, userAgent, apiKey, timeout, gson);
         this.gson = gson;
+        this.requestInterceptors = requestInterceptors;
+        this.responseInterceptors = responseInterceptors;
 
         List<Header> defaultHeaders = new ArrayList<>();
         if (apiKey != null) {
@@ -63,7 +81,37 @@ public class ApacheRequestHandler extends RequestHandler {
                 .build();
     }
 
+    /**
+     * Start building an {@link ApacheRequestHandler} with the given request interceptor.
+     * The returned {@link Builder} implements {@link RequestHandlerConstructor} and can be passed
+     * directly to {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static Builder withRequestInterceptor(RequestInterceptor<HttpUriRequest> interceptor) {
+        return new Builder().withRequestInterceptor(interceptor);
+    }
+
+    /**
+     * Start building an {@link ApacheRequestHandler} with the given response interceptor.
+     * <p>
+     * Note: reading the entity body via {@code response.getEntity().getContent()} inside an
+     * interceptor will consume the stream and break internal JSON parsing. Status code and
+     * headers are always safe to inspect.
+     */
+    public static Builder withResponseInterceptor(ResponseInterceptor<HttpResponse> interceptor) {
+        return new Builder().withResponseInterceptor(interceptor);
+    }
+
+    private HttpResponse execute(HttpUriRequest request) throws IOException {
+        for (RequestInterceptor<HttpUriRequest> interceptor : requestInterceptors) {
+            interceptor.intercept(request);
+        }
+        return this.httpClient.execute(request);
+    }
+
     private <T, R extends MineSkinResponse<T>> R wrapResponse(HttpResponse response, Class<T> clazz, ResponseConstructor<T, R> constructor) throws IOException {
+        for (ResponseInterceptor<HttpResponse> interceptor : responseInterceptors) {
+            interceptor.intercept(response);
+        }
         String rawBody = null;
         try {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent()))) {
@@ -103,7 +151,7 @@ public class ApacheRequestHandler extends RequestHandler {
     public <T, R extends MineSkinResponse<T>> R getJson(String url, Class<T> clazz, ResponseConstructor<T, R> constructor) throws IOException {
         url = this.baseUrl + url;
         MineSkinClientImpl.LOGGER.fine("GET " + url);
-        HttpResponse response = this.httpClient.execute(new HttpGet(url));
+        HttpResponse response = execute(new HttpGet(url));
         return wrapResponse(response, clazz, constructor);
     }
 
@@ -115,7 +163,7 @@ public class ApacheRequestHandler extends RequestHandler {
         post.setHeader("Content-Type", ContentType.APPLICATION_JSON.getMimeType());
         StringEntity entity = new StringEntity(gson.toJson(data), ContentType.APPLICATION_JSON);
         post.setEntity(entity);
-        HttpResponse response = this.httpClient.execute(post);
+        HttpResponse response = execute(post);
         return wrapResponse(response, clazz, constructor);
     }
 
@@ -132,8 +180,38 @@ public class ApacheRequestHandler extends RequestHandler {
         }
         HttpEntity entity = multipart.build();
         post.setEntity(entity);
-        HttpResponse response = this.httpClient.execute(post);
+        HttpResponse response = execute(post);
         return wrapResponse(response, clazz, constructor);
+    }
+
+    /**
+     * Builder for an {@link ApacheRequestHandler} configured with request and/or response interceptors.
+     * Implements {@link RequestHandlerConstructor} so it can be passed directly to
+     * {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static final class Builder implements RequestHandlerConstructor {
+
+        private final List<RequestInterceptor<HttpUriRequest>> requestInterceptors = new ArrayList<>();
+        private final List<ResponseInterceptor<HttpResponse>> responseInterceptors = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder withRequestInterceptor(RequestInterceptor<HttpUriRequest> interceptor) {
+            this.requestInterceptors.add(interceptor);
+            return this;
+        }
+
+        public Builder withResponseInterceptor(ResponseInterceptor<HttpResponse> interceptor) {
+            this.responseInterceptors.add(interceptor);
+            return this;
+        }
+
+        @Override
+        public RequestHandler construct(String baseUrl, String userAgent, String apiKey, int timeout, Gson gson) {
+            return new ApacheRequestHandler(baseUrl, userAgent, apiKey, timeout, gson,
+                    List.copyOf(requestInterceptors), List.copyOf(responseInterceptors));
+        }
     }
 
 }

--- a/core/src/main/java/org/mineskin/request/RequestInterceptor.java
+++ b/core/src/main/java/org/mineskin/request/RequestInterceptor.java
@@ -1,0 +1,16 @@
+package org.mineskin.request;
+
+/**
+ * Interceptor invoked just before a request is sent. The type parameter exposes
+ * the underlying {@link RequestHandler}'s native request type (e.g.
+ * {@code HttpRequest.Builder} for the Java 11 handler, {@code HttpUriRequest}
+ * for the Apache handler, {@code org.jsoup.Connection} for the Jsoup handler).
+ *
+ * @param <R> native request type for the target {@link RequestHandler}
+ */
+@FunctionalInterface
+public interface RequestInterceptor<R> {
+
+    void intercept(R request);
+
+}

--- a/core/src/main/java/org/mineskin/request/ResponseInterceptor.java
+++ b/core/src/main/java/org/mineskin/request/ResponseInterceptor.java
@@ -1,0 +1,15 @@
+package org.mineskin.request;
+
+/**
+ * Interceptor invoked after a response is received, before the body is parsed
+ * or the response is checked for errors. The type parameter exposes the
+ * underlying {@link RequestHandler}'s native response type.
+ *
+ * @param <R> native response type for the target {@link RequestHandler}
+ */
+@FunctionalInterface
+public interface ResponseInterceptor<R> {
+
+    void intercept(R response);
+
+}

--- a/java11/src/main/java/org/mineskin/Java11RequestHandler.java
+++ b/java11/src/main/java/org/mineskin/Java11RequestHandler.java
@@ -7,6 +7,9 @@ import org.mineskin.data.CodeAndMessage;
 import org.mineskin.exception.MineSkinRequestException;
 import org.mineskin.exception.MineskinException;
 import org.mineskin.request.RequestHandler;
+import org.mineskin.request.RequestHandlerConstructor;
+import org.mineskin.request.RequestInterceptor;
+import org.mineskin.request.ResponseInterceptor;
 import org.mineskin.response.MineSkinResponse;
 import org.mineskin.response.ResponseConstructor;
 
@@ -15,9 +18,11 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -26,10 +31,20 @@ public class Java11RequestHandler extends RequestHandler {
 
     private final Gson gson;
     private final HttpClient httpClient;
+    private final List<RequestInterceptor<HttpRequest.Builder>> requestInterceptors;
+    private final List<ResponseInterceptor<HttpResponse<String>>> responseInterceptors;
 
     public Java11RequestHandler(String baseUrl, String userAgent, String apiKey, int timeout, Gson gson) {
+        this(baseUrl, userAgent, apiKey, timeout, gson, List.of(), List.of());
+    }
+
+    private Java11RequestHandler(String baseUrl, String userAgent, String apiKey, int timeout, Gson gson,
+                                 List<RequestInterceptor<HttpRequest.Builder>> requestInterceptors,
+                                 List<ResponseInterceptor<HttpResponse<String>>> responseInterceptors) {
         super(baseUrl, userAgent, apiKey, timeout, gson);
         this.gson = gson;
+        this.requestInterceptors = requestInterceptors;
+        this.responseInterceptors = responseInterceptors;
 
         HttpClient.Builder clientBuilder = HttpClient.newBuilder()
                 .connectTimeout(java.time.Duration.ofMillis(timeout));
@@ -40,7 +55,28 @@ public class Java11RequestHandler extends RequestHandler {
         this.httpClient = clientBuilder.build();
     }
 
+    /**
+     * Start building a {@link Java11RequestHandler} with the given request interceptor.
+     * The returned {@link Builder} implements {@link RequestHandlerConstructor} and can be passed
+     * directly to {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static Builder withRequestInterceptor(RequestInterceptor<HttpRequest.Builder> interceptor) {
+        return new Builder().withRequestInterceptor(interceptor);
+    }
+
+    /**
+     * Start building a {@link Java11RequestHandler} with the given response interceptor.
+     * The returned {@link Builder} implements {@link RequestHandlerConstructor} and can be passed
+     * directly to {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static Builder withResponseInterceptor(ResponseInterceptor<HttpResponse<String>> interceptor) {
+        return new Builder().withResponseInterceptor(interceptor);
+    }
+
     private <T, R extends MineSkinResponse<T>> R wrapResponse(HttpResponse<String> response, Class<T> clazz, ResponseConstructor<T, R> constructor) throws IOException {
+        for (ResponseInterceptor<HttpResponse<String>> interceptor : responseInterceptors) {
+            interceptor.intercept(response);
+        }
         String rawBody = response.body();
         try {
             JsonObject jsonBody = gson.fromJson(rawBody, JsonObject.class);
@@ -72,22 +108,26 @@ public class Java11RequestHandler extends RequestHandler {
                 ));
     }
 
+    private HttpRequest buildRequest(HttpRequest.Builder requestBuilder) {
+        if (apiKey != null) {
+            requestBuilder
+                    .header("Authorization", "Bearer " + apiKey)
+                    .header("Accept", "application/json");
+        }
+        for (RequestInterceptor<HttpRequest.Builder> interceptor : requestInterceptors) {
+            interceptor.intercept(requestBuilder);
+        }
+        return requestBuilder.build();
+    }
+
     public <T, R extends MineSkinResponse<T>> R getJson(String url, Class<T> clazz, ResponseConstructor<T, R> constructor) throws IOException {
         url = this.baseUrl + url;
         MineSkinClientImpl.LOGGER.fine("GET " + url);
 
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        HttpRequest request = buildRequest(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .GET()
-                .header("User-Agent", this.userAgent);
-        HttpRequest request;
-        if (apiKey != null) {
-            request = requestBuilder
-                    .header("Authorization", "Bearer " + apiKey)
-                    .header("Accept", "application/json").build();
-        } else {
-            request = requestBuilder.build();
-        }
+                .header("User-Agent", this.userAgent));
         HttpResponse<String> response;
         try {
             response = this.httpClient.send(request, BodyHandlers.ofString());
@@ -101,19 +141,11 @@ public class Java11RequestHandler extends RequestHandler {
         url = this.baseUrl + url;
         MineSkinClientImpl.LOGGER.fine("POST " + url);
 
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        HttpRequest request = buildRequest(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .POST(BodyPublishers.ofString(gson.toJson(data)))
                 .header("Content-Type", "application/json")
-                .header("User-Agent", this.userAgent);
-        HttpRequest request;
-        if (apiKey != null) {
-            request = requestBuilder
-                    .header("Authorization", "Bearer " + apiKey)
-                    .header("Accept", "application/json").build();
-        } else {
-            request = requestBuilder.build();
-        }
+                .header("User-Agent", this.userAgent));
 
         HttpResponse<String> response;
         try {
@@ -151,19 +183,11 @@ public class Java11RequestHandler extends RequestHandler {
         System.arraycopy(fileContent, 0, bodyString, bodyStart.length, fileContent.length);
         System.arraycopy(boundaryEnd, 0, bodyString, bodyStart.length + fileContent.length, boundaryEnd.length);
 
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        HttpRequest request = buildRequest(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .POST(HttpRequest.BodyPublishers.ofByteArray(bodyString))
                 .header("Content-Type", "multipart/form-data; boundary=" + boundary)
-                .header("User-Agent", this.userAgent);
-        HttpRequest request;
-        if (apiKey != null) {
-            request = requestBuilder
-                    .header("Authorization", "Bearer " + apiKey)
-                    .header("Accept", "application/json").build();
-        } else {
-            request = requestBuilder.build();
-        }
+                .header("User-Agent", this.userAgent));
 
         HttpResponse<String> response;
         try {
@@ -172,5 +196,35 @@ public class Java11RequestHandler extends RequestHandler {
             throw new RuntimeException(e);
         }
         return wrapResponse(response, clazz, constructor);
+    }
+
+    /**
+     * Builder for a {@link Java11RequestHandler} configured with request and/or response interceptors.
+     * Implements {@link RequestHandlerConstructor} so it can be passed directly to
+     * {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static final class Builder implements RequestHandlerConstructor {
+
+        private final List<RequestInterceptor<HttpRequest.Builder>> requestInterceptors = new ArrayList<>();
+        private final List<ResponseInterceptor<HttpResponse<String>>> responseInterceptors = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder withRequestInterceptor(RequestInterceptor<HttpRequest.Builder> interceptor) {
+            this.requestInterceptors.add(interceptor);
+            return this;
+        }
+
+        public Builder withResponseInterceptor(ResponseInterceptor<HttpResponse<String>> interceptor) {
+            this.responseInterceptors.add(interceptor);
+            return this;
+        }
+
+        @Override
+        public RequestHandler construct(String baseUrl, String userAgent, String apiKey, int timeout, Gson gson) {
+            return new Java11RequestHandler(baseUrl, userAgent, apiKey, timeout, gson,
+                    List.copyOf(requestInterceptors), List.copyOf(responseInterceptors));
+        }
     }
 }

--- a/jsoup/src/main/java/org/mineskin/JsoupRequestHandler.java
+++ b/jsoup/src/main/java/org/mineskin/JsoupRequestHandler.java
@@ -9,11 +9,16 @@ import org.mineskin.data.CodeAndMessage;
 import org.mineskin.exception.MineSkinRequestException;
 import org.mineskin.exception.MineskinException;
 import org.mineskin.request.RequestHandler;
+import org.mineskin.request.RequestHandlerConstructor;
+import org.mineskin.request.RequestInterceptor;
+import org.mineskin.request.ResponseInterceptor;
 import org.mineskin.response.MineSkinResponse;
 import org.mineskin.response.ResponseConstructor;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -23,16 +28,48 @@ public class JsoupRequestHandler extends RequestHandler {
     private final String userAgent;
     private final String apiKey;
     private final int timeout;
+    private final List<RequestInterceptor<Connection>> requestInterceptors;
+    private final List<ResponseInterceptor<Connection.Response>> responseInterceptors;
 
     public JsoupRequestHandler(
             String baseUrl,
             String userAgent, String apiKey,
             int timeout,
             Gson gson) {
+        this(baseUrl, userAgent, apiKey, timeout, gson, List.of(), List.of());
+    }
+
+    private JsoupRequestHandler(
+            String baseUrl,
+            String userAgent, String apiKey,
+            int timeout,
+            Gson gson,
+            List<RequestInterceptor<Connection>> requestInterceptors,
+            List<ResponseInterceptor<Connection.Response>> responseInterceptors) {
         super(baseUrl, userAgent, apiKey, timeout, gson);
         this.userAgent = userAgent;
         this.apiKey = apiKey;
         this.timeout = timeout;
+        this.requestInterceptors = requestInterceptors;
+        this.responseInterceptors = responseInterceptors;
+    }
+
+    /**
+     * Start building a {@link JsoupRequestHandler} with the given request interceptor.
+     * The returned {@link Builder} implements {@link RequestHandlerConstructor} and can be passed
+     * directly to {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static Builder withRequestInterceptor(RequestInterceptor<Connection> interceptor) {
+        return new Builder().withRequestInterceptor(interceptor);
+    }
+
+    /**
+     * Start building a {@link JsoupRequestHandler} with the given response interceptor.
+     * The returned {@link Builder} implements {@link RequestHandlerConstructor} and can be passed
+     * directly to {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static Builder withResponseInterceptor(ResponseInterceptor<Connection.Response> interceptor) {
+        return new Builder().withResponseInterceptor(interceptor);
     }
 
     private Connection requestBase(Connection.Method method, String url) {
@@ -50,7 +87,17 @@ public class JsoupRequestHandler extends RequestHandler {
         return connection;
     }
 
+    private Connection.Response execute(Connection connection) throws IOException {
+        for (RequestInterceptor<Connection> interceptor : requestInterceptors) {
+            interceptor.intercept(connection);
+        }
+        return connection.execute();
+    }
+
     private <T, R extends MineSkinResponse<T>> R wrapResponse(Connection.Response response, Class<T> clazz, ResponseConstructor<T, R> constructor) {
+        for (ResponseInterceptor<Connection.Response> interceptor : responseInterceptors) {
+            interceptor.intercept(response);
+        }
         try {
             JsonObject jsonBody = gson.fromJson(response.body(), JsonObject.class);
             R wrapped = constructor.construct(
@@ -80,16 +127,16 @@ public class JsoupRequestHandler extends RequestHandler {
 
     @Override
     public <T, R extends MineSkinResponse<T>> R getJson(String url, Class<T> clazz, ResponseConstructor<T, R> constructor) throws IOException {
-        Connection.Response response = requestBase(Connection.Method.GET, url).execute();
+        Connection.Response response = execute(requestBase(Connection.Method.GET, url));
         return wrapResponse(response, clazz, constructor);
     }
 
     @Override
     public <T, R extends MineSkinResponse<T>> R postJson(String url, JsonObject data, Class<T> clazz, ResponseConstructor<T, R> constructor) throws IOException {
-        Connection.Response response = requestBase(Connection.Method.POST, url)
+        Connection connection = requestBase(Connection.Method.POST, url)
                 .requestBody(data.toString())
-                .header("Content-Type", "application/json")
-                .execute();
+                .header("Content-Type", "application/json");
+        Connection.Response response = execute(connection);
         return wrapResponse(response, clazz, constructor);
     }
 
@@ -102,8 +149,38 @@ public class JsoupRequestHandler extends RequestHandler {
                 .header("Content-Type", "multipart/form-data");
         connection.data(key, filename, in);
         connection.data(data);
-        Connection.Response response = connection.execute();
+        Connection.Response response = execute(connection);
         return wrapResponse(response, clazz, constructor);
+    }
+
+    /**
+     * Builder for a {@link JsoupRequestHandler} configured with request and/or response interceptors.
+     * Implements {@link RequestHandlerConstructor} so it can be passed directly to
+     * {@link ClientBuilder#requestHandler(RequestHandlerConstructor)}.
+     */
+    public static final class Builder implements RequestHandlerConstructor {
+
+        private final List<RequestInterceptor<Connection>> requestInterceptors = new ArrayList<>();
+        private final List<ResponseInterceptor<Connection.Response>> responseInterceptors = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder withRequestInterceptor(RequestInterceptor<Connection> interceptor) {
+            this.requestInterceptors.add(interceptor);
+            return this;
+        }
+
+        public Builder withResponseInterceptor(ResponseInterceptor<Connection.Response> interceptor) {
+            this.responseInterceptors.add(interceptor);
+            return this;
+        }
+
+        @Override
+        public RequestHandler construct(String baseUrl, String userAgent, String apiKey, int timeout, Gson gson) {
+            return new JsoupRequestHandler(baseUrl, userAgent, apiKey, timeout, gson,
+                    List.copyOf(requestInterceptors), List.copyOf(responseInterceptors));
+        }
     }
 
 }


### PR DESCRIPTION
Each handler (Java11, Apache, Jsoup) now exposes static withRequestInterceptor/withResponseInterceptor factories that return a Builder implementing RequestHandlerConstructor. Interceptors get typed access to the native request/response (HttpRequest.Builder, HttpUriRequest, Connection, etc). Existing Handler::new usage is unchanged.