### PR TITLE
 Handle non-JSON response bodies in JsoupRequestHandler

### DIFF
--- a/jsoup/src/main/java/org/mineskin/JsoupRequestHandler.java
+++ b/jsoup/src/main/java/org/mineskin/JsoupRequestHandler.java
@@ -1,8 +1,11 @@
 package org.mineskin;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.mineskin.data.CodeAndMessage;
@@ -99,7 +102,7 @@ public class JsoupRequestHandler extends RequestHandler {
             interceptor.intercept(response);
         }
         try {
-            JsonObject jsonBody = gson.fromJson(response.body(), JsonObject.class);
+            JsonObject jsonBody = parseJsonBody(response);
             R wrapped = constructor.construct(
                     response.statusCode(),
                     lowercaseHeaders(response.headers()),
@@ -118,6 +121,31 @@ public class JsoupRequestHandler extends RequestHandler {
             MineSkinClientImpl.LOGGER.log(Level.WARNING, "Failed to parse response body: " + response.body(), e);
             throw new MineskinException("Failed to parse response", e);
         }
+    }
+
+    private JsonObject parseJsonBody(Connection.Response response) {
+        JsonElement parsed;
+        try {
+            parsed = gson.fromJson(response.body(), JsonElement.class);
+        } catch (JsonParseException e) {
+            return syntheticErrorBody(response, "invalid_json", e.getMessage());
+        }
+        if (parsed != null && parsed.isJsonObject()) return parsed.getAsJsonObject();
+        String snippet = response.body() == null ? "null" : response.body();
+        if (snippet.length() > 200) snippet = snippet.substring(0, 200) + "...";
+        return syntheticErrorBody(response, "non_json_response", "HTTP " + response.statusCode() + ": " + snippet);
+    }
+
+    private JsonObject syntheticErrorBody(Connection.Response response, String code, String message) {
+        JsonObject error = new JsonObject();
+        error.add("code", new JsonPrimitive(code));
+        error.add("message", new JsonPrimitive(message == null ? "" : message));
+        JsonArray errors = new JsonArray();
+        errors.add(error);
+        JsonObject body = new JsonObject();
+        body.add("success", new JsonPrimitive(false));
+        body.add("errors", errors);
+        return body;
     }
 
     private Map<String, String> lowercaseHeaders(Map<String, String> headers) {

--- a/jsoup/src/main/java/org/mineskin/JsoupRequestHandler.java
+++ b/jsoup/src/main/java/org/mineskin/JsoupRequestHandler.java
@@ -128,15 +128,15 @@ public class JsoupRequestHandler extends RequestHandler {
         try {
             parsed = gson.fromJson(response.body(), JsonElement.class);
         } catch (JsonParseException e) {
-            return syntheticErrorBody(response, "invalid_json", e.getMessage());
+            return syntheticErrorBody("invalid_json", e.getMessage());
         }
         if (parsed != null && parsed.isJsonObject()) return parsed.getAsJsonObject();
         String snippet = response.body() == null ? "null" : response.body();
         if (snippet.length() > 200) snippet = snippet.substring(0, 200) + "...";
-        return syntheticErrorBody(response, "non_json_response", "HTTP " + response.statusCode() + ": " + snippet);
+        return syntheticErrorBody("non_json_response", "HTTP " + response.statusCode() + ": " + snippet);
     }
 
-    private JsonObject syntheticErrorBody(Connection.Response response, String code, String message) {
+    private JsonObject syntheticErrorBody(String code, String message) {
         JsonObject error = new JsonObject();
         error.add("code", new JsonPrimitive(code));
         error.add("message", new JsonPrimitive(message == null ? "" : message));


### PR DESCRIPTION
When the API returns a non-JSON body (e.g. a Cloudflare 530 with an error page), `JsoupRequestHandler.wrapResponse` calls `gson.fromJson(body, JsonObject.class)` and throws:

```
com.google.gson.JsonSyntaxException: Expected a com.google.gson.JsonObject but was com.google.gson.JsonPrimitive; at path $
	at org.mineskin.JsoupRequestHandler.wrapResponse(JsoupRequestHandler.java:102)
	at org.mineskin.JsoupRequestHandler.getJson(JsoupRequestHandler.java:131)
	at org.mineskin.MineSkinClientImpl$MiscClientImpl.lambda$getUser$0(MineSkinClientImpl.java:348)
```

The specific line that blows up is `JsonObject jsonBody = gson.fromJson(response.body(), JsonObject.class);`. Ran into it during the periodic `misc().getUser()` poll from `AutoGenerateQueueOptions.reloadGrants`, while `/v2/me` was returning 530.

The fix parses the body as JsonElement: if it's not a JsonObject (or parsing fails), I build a synthetic body `{ "success": false, "errors": [{ "code": "non_json_response", "message": "HTTP 530: <snippet>" }] }` so `AbstractMineSkinResponse` consumes it normally and the flow ends up in the existing path that throws `MineSkinRequestException`, which `AutoGenerateQueueOptions` already handles via `.exceptionally(...)`.